### PR TITLE
Unregister the agent during uninstall

### DIFF
--- a/api/unregister-agent.go
+++ b/api/unregister-agent.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/certkit-io/certkit-agent/auth"
+	"github.com/certkit-io/certkit-agent/config"
+)
+
+func UnregisterAgent(cfg config.Config) error {
+	if strings.TrimSpace(cfg.ApiBase) == "" {
+		return fmt.Errorf("missing api base")
+	}
+	if cfg.Agent == nil || strings.TrimSpace(cfg.Agent.AgentId) == "" {
+		return fmt.Errorf("missing agent id")
+	}
+	if cfg.Auth == nil || cfg.Auth.KeyPair == nil {
+		return fmt.Errorf("missing auth key pair")
+	}
+
+	requestBody := []byte("{}")
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("%s/api/agent/v1/%s/unregister", cfg.ApiBase, cfg.Agent.AgentId),
+		bytes.NewReader(requestBody),
+	)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	privKey, err := cfg.Auth.KeyPair.DecodePrivateKey()
+	if err != nil {
+		return fmt.Errorf("decode private key: %w", err)
+	}
+
+	if err := auth.SignRequest(req, cfg.Agent.AgentId, cfg.Version.Version, privKey, time.Now()); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("unregister failed: status=%d read body: %w", resp.StatusCode, err)
+	}
+
+	return fmt.Errorf("unregister failed: status=%d body=%s", resp.StatusCode, body)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func SaveConfig(cfg *Config, path string) error {
 	return utils.WriteFileAtomic(path, configBytes, 0o600)
 }
 
-func LoadConfig(path string, version VersionInfo) (Config, error) {
+func ReadConfigFile(path string) (Config, error) {
 	var cfg Config
 
 	if path == "" {
@@ -127,6 +127,15 @@ func LoadConfig(path string, version VersionInfo) (Config, error) {
 
 	if err := json.Unmarshal(b, &cfg); err != nil {
 		return cfg, fmt.Errorf("failed to parse config file %s: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+func LoadConfig(path string, version VersionInfo) (Config, error) {
+	cfg, err := ReadConfigFile(path)
+	if err != nil {
+		return cfg, err
 	}
 
 	// // Exactly one of Bootstrap or Agent should be present

--- a/dev/systemd/README.md
+++ b/dev/systemd/README.md
@@ -22,6 +22,7 @@ docker compose -f systemd.docker-compose.yml up --build
 
 Monitor
 ```bash
+docker exec -it certkit-systemd-dev systemctl status certkit-agent-bootstrap --no-pager
 docker exec -it certkit-systemd-dev systemctl status certkit-agent --no-pager
 docker exec -it certkit-systemd-dev systemctl status nginx --no-pager
 docker exec -it certkit-systemd-dev journalctl -u certkit-agent -f
@@ -43,3 +44,4 @@ Notes
 - Use `CERTKIT_AGENT_SOURCE=local` (default) to build from local source.
 - Use `CERTKIT_AGENT_SOURCE=release` to install from the published install script.
 - The bootstrap unit runs at container boot and re-installs/updates the service each time.
+- If units do not appear enabled after changes, rebuild with `--no-cache`.

--- a/install/linux.go
+++ b/install/linux.go
@@ -167,6 +167,8 @@ func UninstallLinux(args []string, defaultServiceName string) {
 		}
 	}
 
+	unregisterAgent(*configPath)
+
 	if err := os.Remove(*configPath); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("failed to remove config file %s: %v", *configPath, err)
 	}

--- a/install/unregister.go
+++ b/install/unregister.go
@@ -1,0 +1,44 @@
+package install
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/config"
+)
+
+func unregisterAgent(configPath string) {
+	cfg, err := loadConfigForUnregister(configPath)
+	if err != nil {
+		log.Printf("Agent unregister skipped: %v", err)
+		return
+	}
+
+	if err := api.UnregisterAgent(cfg); err != nil {
+		log.Printf("Agent unregister failed for %s: %v", cfg.Agent.AgentId, err)
+		return
+	}
+
+	log.Printf("Agent unregister succeeded for %s", cfg.Agent.AgentId)
+}
+
+func loadConfigForUnregister(configPath string) (config.Config, error) {
+	cfg, err := config.ReadConfigFile(configPath)
+	if err != nil {
+		return cfg, err
+	}
+
+	if strings.TrimSpace(cfg.ApiBase) == "" {
+		return cfg, fmt.Errorf("config %s missing api_base", configPath)
+	}
+	if cfg.Agent == nil || strings.TrimSpace(cfg.Agent.AgentId) == "" {
+		return cfg, fmt.Errorf("config %s missing agent id", configPath)
+	}
+	if cfg.Auth == nil || cfg.Auth.KeyPair == nil || strings.TrimSpace(cfg.Auth.KeyPair.PrivateKey) == "" {
+		return cfg, fmt.Errorf("config %s missing auth private key", configPath)
+	}
+
+	return cfg, nil
+}

--- a/install/windows.go
+++ b/install/windows.go
@@ -165,6 +165,8 @@ func UninstallWindows(args []string, defaultServiceName string) {
 		log.Printf("Warning: failed to remove Add/Remove Programs entry: %v", err)
 	}
 
+	unregisterAgent(*configPath)
+
 	if err := os.Remove(*configPath); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("failed to remove config file %s: %v", *configPath, err)
 	}


### PR DESCRIPTION
The agent now makes a best effort call to the CertKit API to unregister itself during uninstall.  If the call fails for any reason uninstall continues and the user will just have to clean up the agent in the UI manually later.  