### PR TITLE
Agent can upgrade itself upon signal from CertKit

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
 	"github.com/certkit-io/certkit-agent/inventory"
+	"github.com/certkit-io/certkit-agent/selfupdate"
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
@@ -71,6 +72,15 @@ func PollForConfiguration() (changedIDs map[string]bool, err error) {
 	if response == nil {
 		// No changes from the poll response
 		return nil, nil
+	}
+
+	if response.UpdateAvailable != nil {
+		selfupdate.SignalUpdateAvailable(
+			config.CurrentConfig.Version.Version,
+			response.UpdateAvailable.Version,
+			response.UpdateAvailable.DownloadURL,
+			response.UpdateAvailable.SHA256,
+		)
 	}
 
 	if response.Keystore != nil {

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -29,6 +29,13 @@ type ConfigurationPollResponse struct {
 	UpdatedCertificateConfigurations []config.CertificateConfiguration `json:"updated_certificate_configurations"`
 	LockRequested                    bool                              `json:"lock_requested"`
 	Keystore                         *config.KeystoreConfig            `json:"keystore,omitempty"`
+	UpdateAvailable                  *UpdateSignal                     `json:"update_available,omitempty"`
+}
+
+type UpdateSignal struct {
+	Version     string `json:"version"`
+	DownloadURL string `json:"download_url"`
+	SHA256      string `json:"sha256"`
 }
 
 func PollForConfiguration() (*ConfigurationPollResponse, error) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -129,6 +130,7 @@ func SignRequest(req *http.Request, agentID string, agentVersion string, priv ed
 	if agentVersion != "" {
 		req.Header.Set("X-Agent-Version", agentVersion)
 	}
+	req.Header.Set("X-Agent-Arch", runtime.GOARCH)
 	req.Header.Set("X-Agent-Timestamp", strconv.FormatInt(ts, 10))
 	req.Header.Set("X-Agent-Content-SHA256", bodyHash)
 

--- a/cmd/certkit-agent/run_common.go
+++ b/cmd/certkit-agent/run_common.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/certkit-io/certkit-agent/agent"
 	"github.com/certkit-io/certkit-agent/config"
+	"github.com/certkit-io/certkit-agent/selfupdate"
 )
 
 type runOptions struct {
@@ -76,6 +77,9 @@ func runAgent(opts runOptions) {
 			return
 		case <-ticker.C:
 			agent.PollAndSync(false)
+			if selfupdate.HandleUpdateIfNeeded(opts.configPath) {
+				selfupdate.TriggerRestart()
+			}
 		}
 	}
 }

--- a/inventory/docker.go
+++ b/inventory/docker.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/utils"
 )
 
 type DockerProvider struct{}
@@ -20,7 +21,7 @@ func (DockerProvider) Name() string {
 }
 
 func (DockerProvider) Collect() ([]api.InventoryItem, error) {
-	if !isContainerEnvironment() {
+	if !utils.IsContainerEnvironment() {
 		return nil, nil
 	}
 
@@ -136,25 +137,6 @@ func dockerMounts() ([]string, error) {
 	}
 
 	return mounts, nil
-}
-
-func isContainerEnvironment() bool {
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-	if _, err := os.Stat("/run/.containerenv"); err == nil {
-		return true
-	}
-	data, err := os.ReadFile("/proc/1/cgroup")
-	if err != nil {
-		return false
-	}
-	content := string(data)
-	return strings.Contains(content, "docker") ||
-		strings.Contains(content, "kubepods") ||
-		strings.Contains(content, "containerd") ||
-		strings.Contains(content, "podman") ||
-		strings.Contains(content, "libpod")
 }
 
 func isDockerMountWhitelisted(mountPoint string) bool {

--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -1,0 +1,176 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/certkit-io/certkit-agent/utils"
+)
+
+// pendingUpdate holds the in-memory update signal from the server.
+// Set by SignalUpdateAvailable, consumed by HandleUpdateIfNeeded.
+var pendingUpdate *updateSignal
+
+type updateSignal struct {
+	Version     string
+	DownloadURL string
+	SHA256      string
+}
+
+// SignalUpdateAvailable stores an update signal in memory. Called from
+// PollForConfiguration when the server includes update_available in the response.
+func SignalUpdateAvailable(currentVersion, version, downloadURL, sha256hex string) {
+	version = strings.TrimSpace(version)
+	if version == "" || downloadURL == "" || sha256hex == "" {
+		return
+	}
+	if version == currentVersion {
+		return
+	}
+	if pendingUpdate != nil && pendingUpdate.Version == version {
+		return
+	}
+
+	pendingUpdate = &updateSignal{
+		Version:     version,
+		DownloadURL: downloadURL,
+		SHA256:      sha256hex,
+	}
+	log.Printf("Self-update: version %s available, queued for update", version)
+}
+
+// HandleUpdateIfNeeded checks for a pending update signal and, if present,
+// downloads, verifies, and replaces the binary. Returns true if the caller
+// should trigger a restart.
+func HandleUpdateIfNeeded(configPath string) bool {
+	if pendingUpdate == nil {
+		return false
+	}
+	signal := pendingUpdate
+	pendingUpdate = nil
+
+	if utils.IsContainerEnvironment() {
+		log.Printf("Running in container, skipping self-update to %s", signal.Version)
+		return false
+	}
+
+	log.Printf("Self-update: downloading version %s", signal.Version)
+
+	exe, err := resolveExecutablePath()
+	if err != nil {
+		log.Printf("Self-update: %v", err)
+		return false
+	}
+
+	ext := filepath.Ext(exe)
+	stagingPath := filepath.Join(filepath.Dir(exe), "certkit-agent.new"+ext)
+
+	if err := downloadAndVerify(signal.DownloadURL, signal.SHA256, stagingPath); err != nil {
+		log.Printf("Self-update: download failed: %v", err)
+		os.Remove(stagingPath)
+		return false
+	}
+
+	log.Printf("Self-update: download verified, replacing binary")
+
+	if err := replaceBinary(stagingPath); err != nil {
+		log.Printf("Self-update: binary replacement failed: %v", err)
+		os.Remove(stagingPath)
+		return false
+	}
+
+	log.Printf("Self-update: binary replaced, restart required")
+	return true
+}
+
+// --- Download ---
+
+func downloadAndVerify(url, expectedSHA256, destPath string) error {
+	expectedSHA256 = strings.ToLower(strings.TrimSpace(expectedSHA256))
+	if expectedSHA256 == "" {
+		return fmt.Errorf("expected SHA256 checksum is empty")
+	}
+
+	dir := filepath.Dir(destPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create download directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".certkit-update-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmpPath)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		cleanup()
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "certkit-agent")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		cleanup()
+		return fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		cleanup()
+		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+		cleanup()
+		return fmt.Errorf("write download: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if actual != expectedSHA256 {
+		os.Remove(tmpPath)
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedSHA256, actual)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("move download to destination: %w", err)
+	}
+	return nil
+}
+
+// --- Helpers ---
+
+func resolveExecutablePath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("determine executable path: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks: %w", err)
+	}
+	return exe, nil
+}

--- a/selfupdate/selfupdate_linux.go
+++ b/selfupdate/selfupdate_linux.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// replaceBinary replaces the currently running binary with the new binary at newPath.
+// On Linux, this is an atomic rename. The running process keeps its open file
+// descriptor to the old inode, which is safe.
+func replaceBinary(newPath string) error {
+	current, err := resolveExecutablePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chmod(newPath, 0o755); err != nil {
+		return fmt.Errorf("chmod new binary: %w", err)
+	}
+
+	if err := os.Rename(newPath, current); err != nil {
+		return fmt.Errorf("rename new binary into place: %w", err)
+	}
+	return nil
+}
+
+// TriggerRestart exits the process so systemd Restart=always restarts it with the new binary.
+func TriggerRestart() {
+	log.Printf("Self-update applied. Exiting for service manager restart...")
+	os.Exit(0)
+}

--- a/selfupdate/selfupdate_windows.go
+++ b/selfupdate/selfupdate_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// replaceBinary replaces the currently running binary with the new binary at newPath.
+// On Windows, a running .exe cannot be overwritten but CAN be renamed. The strategy is:
+// 1. Rename running exe to .old.exe
+// 2. Move new binary to the original path
+// If step 2 fails, .old.exe is renamed back to restore the original state.
+func replaceBinary(newPath string) error {
+	current, err := resolveExecutablePath()
+	if err != nil {
+		return err
+	}
+
+	ext := filepath.Ext(current)
+	oldPath := strings.TrimSuffix(current, ext) + ".old" + ext
+
+	os.Remove(oldPath)
+
+	if err := os.Rename(current, oldPath); err != nil {
+		return fmt.Errorf("rename running binary to .old: %w", err)
+	}
+
+	if err := os.Rename(newPath, current); err != nil {
+		if restoreErr := os.Rename(oldPath, current); restoreErr != nil {
+			return fmt.Errorf("move new binary failed (%w) AND restore failed (%v)", err, restoreErr)
+		}
+		return fmt.Errorf("move new binary into place: %w (original restored)", err)
+	}
+	return nil
+}
+
+// TriggerRestart exits the process so the SCM recovery policy restarts the service.
+// On Windows, the SCM recovery is configured to restart on failure (non-zero exit).
+func TriggerRestart() {
+	log.Printf("Self-update applied. Exiting for service manager restart...")
+	os.Exit(1)
+}

--- a/utils/container.go
+++ b/utils/container.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+// IsContainerEnvironment reports whether the process is running inside a
+// container (Docker, Kubernetes, Podman, etc.).
+func IsContainerEnvironment() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	return strings.Contains(content, "docker") ||
+		strings.Contains(content, "kubepods") ||
+		strings.Contains(content, "containerd") ||
+		strings.Contains(content, "podman") ||
+		strings.Contains(content, "libpod")
+}

--- a/utils/container_windows.go
+++ b/utils/container_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package utils
+
+// IsContainerEnvironment returns false on Windows. Windows containers are not
+// a supported deployment target for the certkit-agent.
+func IsContainerEnvironment() bool {
+	return false
+}


### PR DESCRIPTION
Starting with v1.9.0, future agent updates can be requested by the user from the UI itself.  This prevents the need to run the installation script again to upgrade the agent.  