### PR TITLE
Cleanup Stale Files, Handle Certificate Format Changes Smoothly

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -119,8 +119,16 @@ func PollForConfiguration() (changedIDs map[string]ConfigChange, err error) {
 		config.CurrentConfig.CertificateConfigurations = response.UpdatedCertificateConfigurations
 	}
 
-	if len(changed) == 0 {
-		return nil, nil
+	hasChanges := false
+	for _, c := range changed {
+		if c.Changed {
+			hasChanges = true
+			break
+		}
+	}
+
+	if !hasChanges {
+		return changed, nil
 	}
 
 	if err := config.SaveConfig(&config.CurrentConfig, config.CurrentPath); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -199,14 +199,18 @@ func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[s
 			prev.ChainDestination != inc.ChainDestination
 
 		var staleFiles []string
-		if prev.KeyDestination != "" && (inc.AllInOne || prev.KeyDestination != inc.KeyDestination) {
-			staleFiles = append(staleFiles, prev.KeyDestination)
-		}
-		if prev.ChainDestination != "" && (strings.TrimSpace(inc.ChainDestination) == "" || prev.ChainDestination != inc.ChainDestination) {
-			staleFiles = append(staleFiles, prev.ChainDestination)
-		}
-		if prev.PemDestination != "" && prev.PemDestination != inc.PemDestination {
-			staleFiles = append(staleFiles, prev.PemDestination)
+		if !inc.UsesWindowsCertStore() {
+			if !inc.IsJKS() {
+				if prev.KeyDestination != "" && (inc.AllInOne || prev.KeyDestination != inc.KeyDestination) {
+					staleFiles = append(staleFiles, prev.KeyDestination)
+				}
+				if prev.ChainDestination != "" && (strings.TrimSpace(inc.ChainDestination) == "" || prev.ChainDestination != inc.ChainDestination) {
+					staleFiles = append(staleFiles, prev.ChainDestination)
+				}
+			}
+			if prev.PemDestination != "" && prev.PemDestination != inc.PemDestination {
+				staleFiles = append(staleFiles, prev.PemDestination)
+			}
 		}
 
 		changedIDs[inc.Id] = ConfigChange{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -169,66 +170,87 @@ func applyLockedConfigUpdates(updated []config.CertificateConfiguration) map[str
 	return changedIDs
 }
 
-func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[string]ConfigChange {
-	changedIDs := make(map[string]ConfigChange)
-	if len(incoming) == 0 {
-		return changedIDs
+func detectChangedConfigs(previousConfigurations, incomingConfigurations []config.CertificateConfiguration) map[string]ConfigChange {
+	configChanges := make(map[string]ConfigChange)
+	if len(incomingConfigurations) == 0 {
+		return configChanges
 	}
 
-	oldByID := make(map[string]config.CertificateConfiguration, len(old))
-	for _, cfg := range old {
+	previousByID := make(map[string]config.CertificateConfiguration, len(previousConfigurations))
+	for _, cfg := range previousConfigurations {
 		if cfg.Id != "" {
-			oldByID[cfg.Id] = cfg
+			previousByID[cfg.Id] = cfg
 		}
 	}
 
-	for _, inc := range incoming {
-		if inc.Id == "" {
+	for _, incoming := range incomingConfigurations {
+		if incoming.Id == "" {
 			continue
 		}
-		prev, existed := oldByID[inc.Id]
+		prev, existed := previousByID[incoming.Id]
 		if !existed {
-			changedIDs[inc.Id] = ConfigChange{Changed: true}
+			configChanges[incoming.Id] = ConfigChange{Changed: true}
 			continue
 		}
 
 		changed := false
-		if !timePtrEqual(prev.LastConfigurationUpdateDate, inc.LastConfigurationUpdateDate) {
+		if !timePtrEqual(prev.LastConfigurationUpdateDate, incoming.LastConfigurationUpdateDate) {
 			changed = true
-		} else if prev.LatestCertificateSha1 != inc.LatestCertificateSha1 {
+		} else if prev.LatestCertificateSha1 != incoming.LatestCertificateSha1 {
 			changed = true
 		}
 
-		formatChanged := prev.AllInOne != inc.AllInOne ||
-			prev.IsPfx != inc.IsPfx ||
-			!strings.EqualFold(prev.ConfigType, inc.ConfigType) ||
-			prev.PemDestination != inc.PemDestination ||
-			prev.KeyDestination != inc.KeyDestination ||
-			prev.ChainDestination != inc.ChainDestination
+		formatChanged := prev.AllInOne != incoming.AllInOne ||
+			prev.IsPfx != incoming.IsPfx ||
+			!strings.EqualFold(prev.ConfigType, incoming.ConfigType) ||
+			prev.PemDestination != incoming.PemDestination ||
+			prev.KeyDestination != incoming.KeyDestination ||
+			prev.ChainDestination != incoming.ChainDestination
 
+		// All file paths the incoming config will use on disk.
+		var incomingPaths []string
+		if incoming.PemDestination != "" {
+			incomingPaths = append(incomingPaths, incoming.PemDestination)
+		}
+		if incoming.KeyDestination != "" {
+			incomingPaths = append(incomingPaths, incoming.KeyDestination)
+		}
+		if incoming.ChainDestination != "" {
+			incomingPaths = append(incomingPaths, incoming.ChainDestination)
+		}
+
+		// All file paths the previous config owned on disk.
+		var prevPaths []string
+		if !prev.UsesWindowsCertStore() {
+			if prev.PemDestination != "" {
+				prevPaths = append(prevPaths, prev.PemDestination)
+			}
+			if !prev.IsJKS() {
+				if prev.KeyDestination != "" {
+					prevPaths = append(prevPaths, prev.KeyDestination)
+				}
+				if prev.ChainDestination != "" {
+					prevPaths = append(prevPaths, prev.ChainDestination)
+				}
+			}
+		}
+
+		// Stale = previously owned but not in the incoming list.
 		var staleFiles []string
-		if !inc.UsesWindowsCertStore() {
-			if !inc.IsJKS() {
-				if prev.KeyDestination != "" && (inc.AllInOne || prev.KeyDestination != inc.KeyDestination) {
-					staleFiles = append(staleFiles, prev.KeyDestination)
-				}
-				if prev.ChainDestination != "" && (inc.ChainDestination == "" || prev.ChainDestination != inc.ChainDestination) {
-					staleFiles = append(staleFiles, prev.ChainDestination)
-				}
-			}
-			if prev.PemDestination != "" && prev.PemDestination != inc.PemDestination {
-				staleFiles = append(staleFiles, prev.PemDestination)
+		for _, prevPath := range prevPaths {
+			if !slices.Contains(incomingPaths, prevPath) {
+				staleFiles = append(staleFiles, prevPath)
 			}
 		}
 
-		changedIDs[inc.Id] = ConfigChange{
+		configChanges[incoming.Id] = ConfigChange{
 			Changed:       changed,
 			FormatChanged: formatChanged,
 			StaleFiles:    staleFiles,
 		}
 	}
 
-	return changedIDs
+	return configChanges
 }
 
 func timePtrEqual(a, b *time.Time) bool {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -204,7 +204,7 @@ func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[s
 				if prev.KeyDestination != "" && (inc.AllInOne || prev.KeyDestination != inc.KeyDestination) {
 					staleFiles = append(staleFiles, prev.KeyDestination)
 				}
-				if prev.ChainDestination != "" && (strings.TrimSpace(inc.ChainDestination) == "" || prev.ChainDestination != inc.ChainDestination) {
+				if prev.ChainDestination != "" && (inc.ChainDestination == "" || prev.ChainDestination != inc.ChainDestination) {
 					staleFiles = append(staleFiles, prev.ChainDestination)
 				}
 			}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,7 +23,7 @@ type ConfigChange struct {
 }
 
 func PollAndSync(forceSync bool) {
-	changedIDs, err := PollForConfiguration()
+	configChanges, err := PollForConfiguration()
 	if err != nil {
 		reportAgentError(err, "", "")
 		return
@@ -32,7 +32,7 @@ func PollAndSync(forceSync bool) {
 		return
 	}
 
-	statuses := SynchronizeCertificates(changedIDs, forceSync)
+	statuses := SynchronizeCertificates(configChanges, forceSync)
 	if len(statuses) > 0 {
 		if err := api.UpdateConfigStatus(statuses); err != nil {
 			reportAgentError(err, "", "")
@@ -68,7 +68,7 @@ func DoRegistration() {
 	SendInventory()
 }
 
-func PollForConfiguration() (changedIDs map[string]ConfigChange, err error) {
+func PollForConfiguration() (configChanges map[string]ConfigChange, err error) {
 	response, err := api.PollForConfiguration()
 	if err != nil {
 		return nil, err
@@ -112,16 +112,15 @@ func PollForConfiguration() (changedIDs map[string]ConfigChange, err error) {
 		}
 	}
 
-	var changed map[string]ConfigChange
 	if isLocked {
-		changed = applyLockedConfigUpdates(response.UpdatedCertificateConfigurations)
+		configChanges = applyLockedConfigUpdates(response.UpdatedCertificateConfigurations)
 	} else {
-		changed = detectChangedConfigs(config.CurrentConfig.CertificateConfigurations, response.UpdatedCertificateConfigurations)
+		configChanges = detectChangedConfigs(config.CurrentConfig.CertificateConfigurations, response.UpdatedCertificateConfigurations)
 		config.CurrentConfig.CertificateConfigurations = response.UpdatedCertificateConfigurations
 	}
 
 	hasChanges := false
-	for _, c := range changed {
+	for _, c := range configChanges {
 		if c.Changed {
 			hasChanges = true
 			break
@@ -129,14 +128,14 @@ func PollForConfiguration() (changedIDs map[string]ConfigChange, err error) {
 	}
 
 	if !hasChanges {
-		return changed, nil
+		return configChanges, nil
 	}
 
 	if err := config.SaveConfig(&config.CurrentConfig, config.CurrentPath); err != nil {
 		return nil, err
 	}
 
-	return changed, nil
+	return configChanges, nil
 }
 
 func applyLockedConfigUpdates(updated []config.CertificateConfiguration) map[string]ConfigChange {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/certkit-io/certkit-agent/api"
@@ -11,6 +12,14 @@ import (
 	"github.com/certkit-io/certkit-agent/selfupdate"
 	"github.com/certkit-io/certkit-agent/utils"
 )
+
+// ConfigChange describes what changed for a single certificate configuration
+// between the previous and incoming poll response.
+type ConfigChange struct {
+	Changed       bool     // true when the config differs from the previous version
+	FormatChanged bool     // true when format-related fields changed (AllInOne, IsPfx, ConfigType, destinations)
+	StaleFiles    []string // old file paths that should be removed after writing the new format
+}
 
 func PollAndSync(forceSync bool) {
 	changedIDs, err := PollForConfiguration()
@@ -58,7 +67,7 @@ func DoRegistration() {
 	SendInventory()
 }
 
-func PollForConfiguration() (changedIDs map[string]bool, err error) {
+func PollForConfiguration() (changedIDs map[string]ConfigChange, err error) {
 	response, err := api.PollForConfiguration()
 	if err != nil {
 		return nil, err
@@ -102,7 +111,7 @@ func PollForConfiguration() (changedIDs map[string]bool, err error) {
 		}
 	}
 
-	var changed map[string]bool
+	var changed map[string]ConfigChange
 	if isLocked {
 		changed = applyLockedConfigUpdates(response.UpdatedCertificateConfigurations)
 	} else {
@@ -121,8 +130,8 @@ func PollForConfiguration() (changedIDs map[string]bool, err error) {
 	return changed, nil
 }
 
-func applyLockedConfigUpdates(updated []config.CertificateConfiguration) map[string]bool {
-	changedIDs := make(map[string]bool)
+func applyLockedConfigUpdates(updated []config.CertificateConfiguration) map[string]ConfigChange {
+	changedIDs := make(map[string]ConfigChange)
 	if len(updated) == 0 || len(config.CurrentConfig.CertificateConfigurations) == 0 {
 		return changedIDs
 	}
@@ -145,15 +154,15 @@ func applyLockedConfigUpdates(updated []config.CertificateConfiguration) map[str
 		if current.LatestCertificateSha1 != incoming.LatestCertificateSha1 {
 			current.LatestCertificateSha1 = incoming.LatestCertificateSha1
 			current.LastCertificateUpdateDate = incoming.LastCertificateUpdateDate
-			changedIDs[current.Id] = true
+			changedIDs[current.Id] = ConfigChange{Changed: true}
 		}
 	}
 
 	return changedIDs
 }
 
-func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[string]bool {
-	changedIDs := make(map[string]bool)
+func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[string]ConfigChange {
+	changedIDs := make(map[string]ConfigChange)
 	if len(incoming) == 0 {
 		return changedIDs
 	}
@@ -171,13 +180,39 @@ func detectChangedConfigs(old, incoming []config.CertificateConfiguration) map[s
 		}
 		prev, existed := oldByID[inc.Id]
 		if !existed {
-			changedIDs[inc.Id] = true
+			changedIDs[inc.Id] = ConfigChange{Changed: true}
 			continue
 		}
+
+		changed := false
 		if !timePtrEqual(prev.LastConfigurationUpdateDate, inc.LastConfigurationUpdateDate) {
-			changedIDs[inc.Id] = true
+			changed = true
 		} else if prev.LatestCertificateSha1 != inc.LatestCertificateSha1 {
-			changedIDs[inc.Id] = true
+			changed = true
+		}
+
+		formatChanged := prev.AllInOne != inc.AllInOne ||
+			prev.IsPfx != inc.IsPfx ||
+			!strings.EqualFold(prev.ConfigType, inc.ConfigType) ||
+			prev.PemDestination != inc.PemDestination ||
+			prev.KeyDestination != inc.KeyDestination ||
+			prev.ChainDestination != inc.ChainDestination
+
+		var staleFiles []string
+		if prev.KeyDestination != "" && (inc.AllInOne || prev.KeyDestination != inc.KeyDestination) {
+			staleFiles = append(staleFiles, prev.KeyDestination)
+		}
+		if prev.ChainDestination != "" && (strings.TrimSpace(inc.ChainDestination) == "" || prev.ChainDestination != inc.ChainDestination) {
+			staleFiles = append(staleFiles, prev.ChainDestination)
+		}
+		if prev.PemDestination != "" && prev.PemDestination != inc.PemDestination {
+			staleFiles = append(staleFiles, prev.PemDestination)
+		}
+
+		changedIDs[inc.Id] = ConfigChange{
+			Changed:       changed,
+			FormatChanged: formatChanged,
+			StaleFiles:    staleFiles,
 		}
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -9,261 +10,241 @@ import (
 
 func timePtr(t time.Time) *time.Time { return &t }
 
-func TestDetectChangedConfigs(t *testing.T) {
-	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	newTime := baseTime.Add(time.Hour)
+var (
+	baseTime = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime  = baseTime.Add(time.Hour)
+)
 
-	tests := []struct {
-		name              string
-		old               []config.CertificateConfiguration
-		incoming          []config.CertificateConfiguration
-		wantChanged       bool
-		wantFormatChanged bool
-		wantStaleFiles    []string
-	}{
-		{
-			name: "no change when dates and sha1 match",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
-			},
-			wantChanged: false,
-		},
-		{
-			name: "new config has no previous entry",
-			old:  []config.CertificateConfiguration{},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), PemDestination: "/a.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: false,
-		},
-		{
-			name: "config changed but format unchanged",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), LatestCertificateSha1: "def", AllInOne: true, PemDestination: "/a.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: false,
-		},
-		{
-			name: "AllInOne switched to PEM+Key, key reused",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil, // key reused at same path, not all-in-one anymore so no stale key
-		},
-		{
-			name: "PEM+Key switched to AllInOne, stale key file",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/a.key"},
-		},
-		{
-			name: "PEM+Chain+Key switched to PEM+Key, stale chain file",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: ""},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/a.chain"},
-		},
-		{
-			name: "PEM destination path changed, old pem is stale",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/old.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/new.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/old.pem"},
-		},
-		{
-			name: "PEM+Chain+Key switched to AllInOne, stale key and chain",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem", ChainDestination: ""},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/a.key", "/a.chain"},
-		},
-		{
-			name: "sha1 changed triggers change",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", PemDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "def", PemDestination: "/a.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: false,
-		},
-		{
-			name: "PEM+Key switched to PEM+Chain+Key, no stale files",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil,
-		},
-		{
-			name: "key destination path changed, old key is stale",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/old.key"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/new.key"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/old.key"},
-		},
-		{
-			name: "chain destination path changed, old chain is stale",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/old.chain"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/new.chain"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/old.chain"},
-		},
-		{
-			name: "Windows cert store skips stale file logic",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "iis", PemDestination: "OldSite:443", KeyDestination: "/old.key"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "iis", PemDestination: "NewSite:443", KeyDestination: "/new.key"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil,
-		},
-		{
-			name: "JKS only tracks PEM destination, not key or chain",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/old.pass", ChainDestination: "/old.chain"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/new.pass", ChainDestination: "/new.chain"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil, // key/chain changes ignored for JKS, pem path unchanged
-		},
-		{
-			name: "JKS with PEM destination changed produces stale pem",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/old.jks"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/new.jks"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    []string{"/old.jks"},
-		},
-		{
-			name: "format changed but dates and sha1 unchanged",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
-			},
-			wantChanged:       false,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil, // old key dest "/a.pem" is still active as pem dest
-		},
-		{
-			name: "IsPfx toggled triggers format change",
-			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), IsPfx: false, PemDestination: "/a.pem"},
-			},
-			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), IsPfx: true, PemDestination: "/a.pem"},
-			},
-			wantChanged:       true,
-			wantFormatChanged: true,
-			wantStaleFiles:    nil,
-		},
-		{
-			name: "empty incoming list returns empty map",
-			old: []config.CertificateConfiguration{
-				{Id: "a", PemDestination: "/a.pem"},
-			},
-			incoming:       []config.CertificateConfiguration{},
-			wantChanged:    false,
-			wantStaleFiles: nil,
-		},
+func assertConfigChange(t *testing.T, result map[string]ConfigChange, id string, wantChanged, wantFormatChanged bool, wantStaleFiles []string) {
+	t.Helper()
+	change, exists := result[id]
+	if !exists {
+		t.Fatalf("expected entry for config %q in result map, got none", id)
 	}
+	if change.Changed != wantChanged {
+		t.Fatalf("Changed = %v, want %v", change.Changed, wantChanged)
+	}
+	if change.FormatChanged != wantFormatChanged {
+		t.Fatalf("FormatChanged = %v, want %v", change.FormatChanged, wantFormatChanged)
+	}
+	if !slices.Equal(change.StaleFiles, wantStaleFiles) {
+		t.Fatalf("StaleFiles = %v, want %v", change.StaleFiles, wantStaleFiles)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := detectChangedConfigs(tt.old, tt.incoming)
-			id := ""
-			if len(tt.incoming) > 0 {
-				id = tt.incoming[0].Id
-			}
+func TestDetectChangedConfigs_NoChangeWhenDatesAndSha1Match(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", false, false, nil)
+}
 
-			change, exists := result[id]
-			if len(tt.incoming) == 0 {
-				if len(result) != 0 {
-					t.Fatalf("expected empty map for empty incoming, got %d entries", len(result))
-				}
-				return
-			}
-			if !exists {
-				t.Fatalf("expected entry for config %q in result map, got none", id)
-			}
+func TestDetectChangedConfigs_NewConfigHasNoPreviousEntry(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), PemDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, false, nil)
+}
 
-			if change.Changed != tt.wantChanged {
-				t.Fatalf("Changed = %v, want %v", change.Changed, tt.wantChanged)
-			}
+func TestDetectChangedConfigs_ConfigChangedButFormatUnchanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), LatestCertificateSha1: "def", AllInOne: true, PemDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, false, nil)
+}
 
-			if change.FormatChanged != tt.wantFormatChanged {
-				t.Fatalf("FormatChanged = %v, want %v", change.FormatChanged, tt.wantFormatChanged)
-			}
+func TestDetectChangedConfigs_AllInOneSwitchedToPEMKey(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+		},
+	)
+	// Old key dest "/a.pem" is still active as PEM destination, not stale.
+	assertConfigChange(t, result, "a", true, true, nil)
+}
 
-			if len(change.StaleFiles) != len(tt.wantStaleFiles) {
-				t.Fatalf("StaleFiles = %v, want %v", change.StaleFiles, tt.wantStaleFiles)
-			}
-			for i, f := range change.StaleFiles {
-				if f != tt.wantStaleFiles[i] {
-					t.Fatalf("StaleFiles[%d] = %q, want %q", i, f, tt.wantStaleFiles[i])
-				}
-			}
-		})
+func TestDetectChangedConfigs_PEMKeySwitchedToAllInOne(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/a.key"})
+}
+
+func TestDetectChangedConfigs_PEMChainKeySwitchedToPEMKey(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: ""},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/a.chain"})
+}
+
+func TestDetectChangedConfigs_PEMDestinationPathChanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/old.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/new.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/old.pem"})
+}
+
+func TestDetectChangedConfigs_PEMChainKeySwitchedToAllInOne(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem", ChainDestination: ""},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/a.key", "/a.chain"})
+}
+
+func TestDetectChangedConfigs_Sha1ChangedTriggersChange(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", PemDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "def", PemDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, false, nil)
+}
+
+func TestDetectChangedConfigs_PEMKeySwitchedToPEMChainKey(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, nil)
+}
+
+func TestDetectChangedConfigs_KeyDestinationPathChanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/old.key"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/new.key"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/old.key"})
+}
+
+func TestDetectChangedConfigs_ChainDestinationPathChanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/old.chain"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/new.chain"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/old.chain"})
+}
+
+func TestDetectChangedConfigs_WindowsCertStoreSkipsStaleFileLogic(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "iis", PemDestination: "OldSite:443", KeyDestination: "/old.key"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "iis", PemDestination: "NewSite:443", KeyDestination: "/new.key"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, nil)
+}
+
+func TestDetectChangedConfigs_JKSOnlyTracksPEMDestination(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/old.pass", ChainDestination: "/old.chain"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/new.pass", ChainDestination: "/new.chain"},
+		},
+	)
+	// Key/chain changes ignored for JKS, PEM path unchanged.
+	assertConfigChange(t, result, "a", true, true, nil)
+}
+
+func TestDetectChangedConfigs_JKSWithPEMDestinationChanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/old.jks"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/new.jks"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, []string{"/old.jks"})
+}
+
+func TestDetectChangedConfigs_FormatChangedButDatesAndSha1Unchanged(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+		},
+	)
+	// Old key dest "/a.pem" is still active as PEM destination.
+	assertConfigChange(t, result, "a", false, true, nil)
+}
+
+func TestDetectChangedConfigs_IsPfxToggledTriggersFormatChange(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), IsPfx: false, PemDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{
+			{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), IsPfx: true, PemDestination: "/a.pem"},
+		},
+	)
+	assertConfigChange(t, result, "a", true, true, nil)
+}
+
+func TestDetectChangedConfigs_EmptyIncomingListReturnsEmptyMap(t *testing.T) {
+	result := detectChangedConfigs(
+		[]config.CertificateConfiguration{
+			{Id: "a", PemDestination: "/a.pem"},
+		},
+		[]config.CertificateConfiguration{},
+	)
+	if len(result) != 0 {
+		t.Fatalf("expected empty map for empty incoming, got %d entries", len(result))
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -54,7 +54,7 @@ func TestDetectChangedConfigs(t *testing.T) {
 		{
 			name: "AllInOne switched to PEM+Key, key reused",
 			old: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
 			},
 			incoming: []config.CertificateConfiguration{
 				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
@@ -69,7 +69,7 @@ func TestDetectChangedConfigs(t *testing.T) {
 				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
 			},
 			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
 			},
 			wantChanged:       true,
 			wantFormatChanged: true,
@@ -105,7 +105,7 @@ func TestDetectChangedConfigs(t *testing.T) {
 				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
 			},
 			incoming: []config.CertificateConfiguration{
-				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: ""},
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem", ChainDestination: ""},
 			},
 			wantChanged:       true,
 			wantFormatChanged: true,
@@ -122,6 +122,111 @@ func TestDetectChangedConfigs(t *testing.T) {
 			wantChanged:       true,
 			wantFormatChanged: false,
 		},
+		{
+			name: "PEM+Key switched to PEM+Chain+Key, no stale files",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil,
+		},
+		{
+			name: "key destination path changed, old key is stale",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/old.key"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/new.key"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/old.key"},
+		},
+		{
+			name: "chain destination path changed, old chain is stale",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/old.chain"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/new.chain"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/old.chain"},
+		},
+		{
+			name: "Windows cert store skips stale file logic",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "iis", PemDestination: "OldSite:443", KeyDestination: "/old.key"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "iis", PemDestination: "NewSite:443", KeyDestination: "/new.key"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil,
+		},
+		{
+			name: "JKS only tracks PEM destination, not key or chain",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/old.pass", ChainDestination: "/old.chain"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/a.jks", KeyDestination: "/new.pass", ChainDestination: "/new.chain"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil, // key/chain changes ignored for JKS, pem path unchanged
+		},
+		{
+			name: "JKS with PEM destination changed produces stale pem",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), ConfigType: "jks", PemDestination: "/old.jks"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), ConfigType: "jks", PemDestination: "/new.jks"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/old.jks"},
+		},
+		{
+			name: "format changed but dates and sha1 unchanged",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			wantChanged:       false,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil, // old key dest "/a.pem" is still active as pem dest
+		},
+		{
+			name: "IsPfx toggled triggers format change",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), IsPfx: false, PemDestination: "/a.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), IsPfx: true, PemDestination: "/a.pem"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil,
+		},
+		{
+			name: "empty incoming list returns empty map",
+			old: []config.CertificateConfiguration{
+				{Id: "a", PemDestination: "/a.pem"},
+			},
+			incoming:       []config.CertificateConfiguration{},
+			wantChanged:    false,
+			wantStaleFiles: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -133,6 +238,12 @@ func TestDetectChangedConfigs(t *testing.T) {
 			}
 
 			change, exists := result[id]
+			if len(tt.incoming) == 0 {
+				if len(result) != 0 {
+					t.Fatalf("expected empty map for empty incoming, got %d entries", len(result))
+				}
+				return
+			}
 			if !exists {
 				t.Fatalf("expected entry for config %q in result map, got none", id)
 			}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/certkit-io/certkit-agent/config"
+)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestDetectChangedConfigs(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime := baseTime.Add(time.Hour)
+
+	tests := []struct {
+		name              string
+		old               []config.CertificateConfiguration
+		incoming          []config.CertificateConfiguration
+		wantChanged       bool
+		wantFormatChanged bool
+		wantStaleFiles    []string
+	}{
+		{
+			name: "no change when dates and sha1 match",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+			},
+			wantChanged: false,
+		},
+		{
+			name: "new config has no previous entry",
+			old:  []config.CertificateConfiguration{},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), PemDestination: "/a.pem"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: false,
+		},
+		{
+			name: "config changed but format unchanged",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", AllInOne: true, PemDestination: "/a.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), LatestCertificateSha1: "def", AllInOne: true, PemDestination: "/a.pem"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: false,
+		},
+		{
+			name: "AllInOne switched to PEM+Key, key reused",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    nil, // key reused at same path, not all-in-one anymore so no stale key
+		},
+		{
+			name: "PEM+Key switched to AllInOne, stale key file",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/a.key"},
+		},
+		{
+			name: "PEM+Chain+Key switched to PEM+Key, stale chain file",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: ""},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/a.chain"},
+		},
+		{
+			name: "PEM destination path changed, old pem is stale",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: true, PemDestination: "/old.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/new.pem"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/old.pem"},
+		},
+		{
+			name: "PEM+Chain+Key switched to AllInOne, stale key and chain",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), AllInOne: false, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: "/a.chain"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(newTime), AllInOne: true, PemDestination: "/a.pem", KeyDestination: "/a.key", ChainDestination: ""},
+			},
+			wantChanged:       true,
+			wantFormatChanged: true,
+			wantStaleFiles:    []string{"/a.key", "/a.chain"},
+		},
+		{
+			name: "sha1 changed triggers change",
+			old: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "abc", PemDestination: "/a.pem"},
+			},
+			incoming: []config.CertificateConfiguration{
+				{Id: "a", LastConfigurationUpdateDate: timePtr(baseTime), LatestCertificateSha1: "def", PemDestination: "/a.pem"},
+			},
+			wantChanged:       true,
+			wantFormatChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectChangedConfigs(tt.old, tt.incoming)
+			id := ""
+			if len(tt.incoming) > 0 {
+				id = tt.incoming[0].Id
+			}
+
+			change, exists := result[id]
+			if !exists {
+				t.Fatalf("expected entry for config %q in result map, got none", id)
+			}
+
+			if change.Changed != tt.wantChanged {
+				t.Fatalf("Changed = %v, want %v", change.Changed, tt.wantChanged)
+			}
+
+			if change.FormatChanged != tt.wantFormatChanged {
+				t.Fatalf("FormatChanged = %v, want %v", change.FormatChanged, tt.wantFormatChanged)
+			}
+
+			if len(change.StaleFiles) != len(tt.wantStaleFiles) {
+				t.Fatalf("StaleFiles = %v, want %v", change.StaleFiles, tt.wantStaleFiles)
+			}
+			for i, f := range change.StaleFiles {
+				if f != tt.wantStaleFiles[i] {
+					t.Fatalf("StaleFiles[%d] = %q, want %q", i, f, tt.wantStaleFiles[i])
+				}
+			}
+		})
+	}
+}

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -28,7 +28,7 @@ const (
 	statusErrorGeneral   = "ERROR_GENERAL"
 )
 
-func SynchronizeCertificates(changedIDs map[string]bool, forceSync bool) []api.AgentConfigStatusUpdate {
+func SynchronizeCertificates(changedIDs map[string]ConfigChange, forceSync bool) []api.AgentConfigStatusUpdate {
 	statuses := make([]api.AgentConfigStatusUpdate, 0, len(config.CurrentConfig.CertificateConfigurations))
 	configDirty := false
 
@@ -37,16 +37,16 @@ func SynchronizeCertificates(changedIDs map[string]bool, forceSync bool) []api.A
 		lastStatus := cfg.LastStatus
 		waitingForWindow := lastStatus == statusWaitingWindow
 		retrySync := lastStatus == statusErrorGetCert || lastStatus == statusErrorWriteCert
-		configChanged := changedIDs[cfg.Id]
+		change := changedIDs[cfg.Id]
 
-		if !configChanged && !forceSync && !waitingForWindow && !retrySync {
+		if !change.Changed && !forceSync && !waitingForWindow && !retrySync {
 			continue
 		}
-		if configChanged {
+		if change.Changed {
 			log.Printf("Config %s changed, synchronizing", cfg.Id)
 		}
 
-		status := synchronizeCertificate(*cfg, configChanged)
+		status := synchronizeCertificate(*cfg, change)
 		if status.ConfigId != "" {
 			if status.Status != "" && status.Status != cfg.LastStatus {
 				statuses = append(statuses, status)
@@ -63,7 +63,7 @@ func SynchronizeCertificates(changedIDs map[string]bool, forceSync bool) []api.A
 	return statuses
 }
 
-func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged bool) api.AgentConfigStatusUpdate {
+func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),
@@ -77,7 +77,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged b
 		return status
 	}
 	if !allowed {
-		if configChanged {
+		if change.Changed {
 			log.Printf("Waiting on synchronization for config %s: outside deploy window: %q", cfg.Id, cfg.UpdateWindow)
 		}
 		status.Status = statusWaitingWindow
@@ -88,16 +88,16 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged b
 	}
 
 	if strings.EqualFold(cfg.ConfigType, "iis") {
-		return synchronizeIISCertificate(cfg, configChanged)
+		return synchronizeIISCertificate(cfg, change)
 	}
 	if strings.EqualFold(cfg.ConfigType, "rras") || strings.EqualFold(cfg.ConfigType, "direct-access") {
-		return synchronizeRemoteAccessCertificate(cfg, configChanged)
+		return synchronizeRemoteAccessCertificate(cfg, change)
 	}
 	if strings.EqualFold(cfg.ConfigType, "rdp") {
-		return synchronizeRDPCertificate(cfg, configChanged)
+		return synchronizeRDPCertificate(cfg, change)
 	}
 	if strings.EqualFold(cfg.ConfigType, "windows-cert-store") {
-		return synchronizeWindowsCertStoreCertificate(cfg, configChanged)
+		return synchronizeWindowsCertStoreCertificate(cfg, change)
 	}
 
 	retryUpdateOnly := cfg.LastStatus == statusErrorUpdateCmd || cfg.LastStatus == statusWaitingWindow
@@ -127,8 +127,8 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged b
 		return status
 	}
 
-	shouldFetch := needsFetch || retryFull
-	needsApply := needsFetch || configChanged || retryUpdateOnly || retryFull
+	shouldFetch := needsFetch || change.FormatChanged || retryFull
+	needsApply := needsFetch || change.Changed || retryUpdateOnly || retryFull
 
 	if shouldFetch {
 		if isJks {
@@ -195,6 +195,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged b
 				status.Message = fmt.Sprintf("Error writing certificate files: %v", err)
 				return status
 			}
+			cleanupStaleFiles(change.StaleFiles)
 		}
 	}
 
@@ -210,7 +211,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, configChanged b
 		if strings.TrimSpace(cfg.UpdateCmd) == "" {
 			log.Print("No update command configured; skipping update command.")
 		} else {
-			if !needsFetch && configChanged {
+			if !needsFetch && change.Changed {
 				log.Print("Running update cmd due to configuration change...")
 			}
 			if (retryUpdateOnly || retryFull) && cfg.LastStatus != statusWaitingWindow {
@@ -409,6 +410,21 @@ func writeCertificateFiles(cfg config.CertificateConfiguration, response *api.Fe
 	}
 
 	return nil
+}
+
+func cleanupStaleFiles(paths []string) {
+	for _, p := range paths {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("Warning: failed to remove stale file %s: %v", p, err)
+			}
+		} else {
+			log.Printf("Removed stale file from previous format: %s", p)
+		}
+	}
 }
 
 func writePfxFiles(cfg config.CertificateConfiguration, response *api.FetchPfxResponse) error {

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -107,7 +107,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 		cfg.LastStatus == statusErrorGeneral
 
 	isPfx := cfg.IsPfx
-	isJks := strings.EqualFold(cfg.ConfigType, "jks")
+	isJks := cfg.IsJKS()
 	requiresKeyDestination := !cfg.AllInOne && !isPfx
 	if cfg.PemDestination == "" || (requiresKeyDestination && cfg.KeyDestination == "") {
 		log.Printf("Skipping certificate config %s: missing destination path(s)", cfg.Id)
@@ -195,8 +195,8 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 				status.Message = fmt.Sprintf("Error writing certificate files: %v", err)
 				return status
 			}
-			cleanupStaleFiles(change.StaleFiles)
 		}
+		cleanupStaleFiles(change.StaleFiles)
 	}
 
 	if needsApply {
@@ -236,7 +236,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 }
 
 func needsCertificateFetch(cfg config.CertificateConfiguration) (bool, error) {
-	if strings.EqualFold(cfg.ConfigType, "jks") {
+	if cfg.IsJKS() {
 		jksExists, err := utils.FileExists(cfg.PemDestination)
 		if err != nil {
 			log.Printf("Failed to stat JKS file %s: %v (forcing fetch)", cfg.PemDestination, err)
@@ -511,7 +511,7 @@ func applyCertificatePermissions(cfg config.CertificateConfiguration) error {
 		return nil
 	}
 
-	isJks := strings.EqualFold(cfg.ConfigType, "jks")
+	isJks := cfg.IsJKS()
 	paths := []string{cfg.PemDestination}
 	if cfg.IsPfx {
 		paths = append(paths, pfxPasswordFilePath(cfg.PemDestination))

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -28,7 +28,7 @@ const (
 	statusErrorGeneral   = "ERROR_GENERAL"
 )
 
-func SynchronizeCertificates(changedIDs map[string]ConfigChange, forceSync bool) []api.AgentConfigStatusUpdate {
+func SynchronizeCertificates(configChanges map[string]ConfigChange, forceSync bool) []api.AgentConfigStatusUpdate {
 	statuses := make([]api.AgentConfigStatusUpdate, 0, len(config.CurrentConfig.CertificateConfigurations))
 	configDirty := false
 
@@ -37,7 +37,7 @@ func SynchronizeCertificates(changedIDs map[string]ConfigChange, forceSync bool)
 		lastStatus := cfg.LastStatus
 		waitingForWindow := lastStatus == statusWaitingWindow
 		retrySync := lastStatus == statusErrorGetCert || lastStatus == statusErrorWriteCert
-		change := changedIDs[cfg.Id]
+		change := configChanges[cfg.Id]
 
 		if !change.Changed && !forceSync && !waitingForWindow && !retrySync {
 			continue
@@ -653,4 +653,3 @@ func resolveGroupId(name string) (int, error) {
 	}
 	return gid, nil
 }
-

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -422,7 +422,7 @@ func cleanupStaleFiles(paths []string) {
 				log.Printf("Warning: failed to remove stale file %s: %v", p, err)
 			}
 		} else {
-			log.Printf("Removed stale file from previous format: %s", p)
+			log.Printf("Removed stale file from previous config: %s", p)
 		}
 	}
 }

--- a/agent/synchronize_iis_other.go
+++ b/agent/synchronize_iis_other.go
@@ -9,7 +9,7 @@ import (
 	"github.com/certkit-io/certkit-agent/config"
 )
 
-func synchronizeIISCertificate(cfg config.CertificateConfiguration, _ bool) api.AgentConfigStatusUpdate {
+func synchronizeIISCertificate(cfg config.CertificateConfiguration, _ ConfigChange) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),

--- a/agent/synchronize_iis_windows.go
+++ b/agent/synchronize_iis_windows.go
@@ -12,7 +12,7 @@ import (
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func synchronizeIISCertificate(cfg config.CertificateConfiguration, configChanged bool) api.AgentConfigStatusUpdate {
+func synchronizeIISCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
 	siteName, port, err := parseIISDestination(cfg.PemDestination)
 	if err != nil {
 		return api.AgentConfigStatusUpdate{
@@ -23,7 +23,7 @@ func synchronizeIISCertificate(cfg config.CertificateConfiguration, configChange
 		}
 	}
 
-	return synchronizeWindowsServiceCert(cfg, configChanged, windowsSyncConfig{
+	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: "IIS",
 		applyFn: func(thumbprint string) (string, error) {
 			return "", applyIISBinding(siteName, port, thumbprint)

--- a/agent/synchronize_rdp_other.go
+++ b/agent/synchronize_rdp_other.go
@@ -9,7 +9,7 @@ import (
 	"github.com/certkit-io/certkit-agent/config"
 )
 
-func synchronizeRDPCertificate(cfg config.CertificateConfiguration, _ bool) api.AgentConfigStatusUpdate {
+func synchronizeRDPCertificate(cfg config.CertificateConfiguration, _ ConfigChange) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),

--- a/agent/synchronize_rdp_windows.go
+++ b/agent/synchronize_rdp_windows.go
@@ -12,7 +12,7 @@ import (
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func synchronizeRDPCertificate(cfg config.CertificateConfiguration, configChanged bool) api.AgentConfigStatusUpdate {
+func synchronizeRDPCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
 	role := strings.TrimSpace(cfg.PemDestination)
 	if role == "" {
 		return api.AgentConfigStatusUpdate{
@@ -23,7 +23,7 @@ func synchronizeRDPCertificate(cfg config.CertificateConfiguration, configChange
 		}
 	}
 
-	return synchronizeWindowsServiceCert(cfg, configChanged, windowsSyncConfig{
+	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: fmt.Sprintf("RDP/%s", role),
 		applyFn: func(thumbprint string) (string, error) {
 			if strings.EqualFold(role, "TerminalServices") || strings.EqualFold(role, "Terminal Services") {

--- a/agent/synchronize_remote_access_other.go
+++ b/agent/synchronize_remote_access_other.go
@@ -9,7 +9,7 @@ import (
 	"github.com/certkit-io/certkit-agent/config"
 )
 
-func synchronizeRemoteAccessCertificate(cfg config.CertificateConfiguration, _ bool) api.AgentConfigStatusUpdate {
+func synchronizeRemoteAccessCertificate(cfg config.CertificateConfiguration, _ ConfigChange) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),

--- a/agent/synchronize_remote_access_windows.go
+++ b/agent/synchronize_remote_access_windows.go
@@ -11,8 +11,8 @@ import (
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func synchronizeRemoteAccessCertificate(cfg config.CertificateConfiguration, configChanged bool) api.AgentConfigStatusUpdate {
-	return synchronizeWindowsServiceCert(cfg, configChanged, windowsSyncConfig{
+func synchronizeRemoteAccessCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
+	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: "RemoteAccess",
 		applyFn: func(thumbprint string) (string, error) {
 			return "", applyRemoteAccessSslCertificate(thumbprint, cfg.ConfigType)

--- a/agent/synchronize_test.go
+++ b/agent/synchronize_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseFileMode(t *testing.T) {
 	tests := []struct {
@@ -43,4 +47,35 @@ func TestParseFileMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanupStaleFiles(t *testing.T) {
+	t.Run("removes existing files", func(t *testing.T) {
+		dir := t.TempDir()
+		f1 := filepath.Join(dir, "key.pem")
+		f2 := filepath.Join(dir, "chain.pem")
+		if err := os.WriteFile(f1, []byte("key"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(f2, []byte("chain"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cleanupStaleFiles([]string{f1, f2})
+
+		if _, err := os.Stat(f1); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", f1)
+		}
+		if _, err := os.Stat(f2); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", f2)
+		}
+	})
+
+	t.Run("handles empty and missing paths gracefully", func(t *testing.T) {
+		cleanupStaleFiles([]string{"", "  ", "/nonexistent/path/file.pem"})
+	})
+
+	t.Run("handles nil slice", func(t *testing.T) {
+		cleanupStaleFiles(nil)
+	})
 }

--- a/agent/synchronize_windows_cert_store_other.go
+++ b/agent/synchronize_windows_cert_store_other.go
@@ -9,7 +9,7 @@ import (
 	"github.com/certkit-io/certkit-agent/config"
 )
 
-func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration, _ bool) api.AgentConfigStatusUpdate {
+func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration, _ ConfigChange) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),

--- a/agent/synchronize_windows_cert_store_windows.go
+++ b/agent/synchronize_windows_cert_store_windows.go
@@ -12,8 +12,8 @@ import (
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration, configChanged bool) api.AgentConfigStatusUpdate {
-	return synchronizeWindowsServiceCert(cfg, configChanged, windowsSyncConfig{
+func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
+	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: "WindowsCertStore",
 		applyFn: func(thumbprint string) (string, error) {
 			if strings.TrimSpace(cfg.UpdateCmd) == "" {

--- a/agent/synchronize_windows_common.go
+++ b/agent/synchronize_windows_common.go
@@ -19,7 +19,7 @@ type windowsSyncConfig struct {
 	applyFn     func(thumbprint string) (string, error)
 }
 
-func synchronizeWindowsServiceCert(cfg config.CertificateConfiguration, configChanged bool, svc windowsSyncConfig) api.AgentConfigStatusUpdate {
+func synchronizeWindowsServiceCert(cfg config.CertificateConfiguration, change ConfigChange, svc windowsSyncConfig) api.AgentConfigStatusUpdate {
 	status := api.AgentConfigStatusUpdate{
 		ConfigId:       cfg.Id,
 		LastStatusDate: time.Now().UTC(),
@@ -52,7 +52,7 @@ func synchronizeWindowsServiceCert(cfg config.CertificateConfiguration, configCh
 	needsFetch := !exists
 
 	shouldFetch := needsFetch || retryFull
-	shouldApply := needsFetch || configChanged || retryUpdateOnly || retryFull
+	shouldApply := needsFetch || change.Changed || retryUpdateOnly || retryFull
 
 	importedPfx := false
 	if shouldFetch {

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,15 @@ type CertificateConfiguration struct {
 	ConfigType                  string     `json:"config_type"`
 }
 
+func (c CertificateConfiguration) UsesWindowsCertStore() bool {
+	ct := strings.ToLower(c.ConfigType)
+	return ct == "windows-cert-store" || ct == "iis" || ct == "rdp" || ct == "rras" || ct == "direct-access"
+}
+
+func (c CertificateConfiguration) IsJKS() bool {
+	return strings.EqualFold(c.ConfigType, "jks")
+}
+
 type VersionInfo struct {
 	Version string
 	Commit  string

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - ../:/app
     env_file:
       - ./.env
-    command: bash -c "go build -ldflags '-X main.version=v1.6.3' -o ./dist/certkit-agent ./cmd/certkit-agent && ./dist/certkit-agent run --config /app/dev/config.json"
+    command: bash -c "go build -ldflags '-X main.version=v1.9.0' -o ./dist/certkit-agent ./cmd/certkit-agent && ./dist/certkit-agent run --config /app/dev/config.json"


### PR DESCRIPTION
There were some edge cases if a user changed a deployed certificate format.  For example, if you changed from PEM + KEY to PEM + KEY + CHAIN our sync logic would not recognize that the pem file needed to be changed (remove the intermediate chain from that, and write it separately). 

We've updated the agent configuration processing to detect format changes, and also clean up stale files (if you move the files from one place to another, or change formats that result in differing numbers of on disk files, the stale ones will now be removed)

