### PR TITLE
Send back up to 100 IIS SSL bindings

### DIFF
--- a/inventory/iis_windows.go
+++ b/inventory/iis_windows.go
@@ -80,7 +80,7 @@ Import-Module WebAdministration
             }
         }
     } |
-    Select-Object -First 10
+    Select-Object -First 100
 ) | ConvertTo-Json
 `
 	out, err := utils.RunPowerShell(script)


### PR DESCRIPTION
We had put a sanity check of 10 on the number of IIS inventory items to return.  This is not sufficient for larger IIS machines with many sites.  Bump the limit to 100 for now.