### PR TITLE
Better Remote Scripting Support

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/certkit-io/certkit-agent/api"
@@ -20,6 +21,31 @@ type ConfigChange struct {
 	Changed       bool     // true when the config differs from the previous version
 	FormatChanged bool     // true when format-related fields changed (AllInOne, IsPfx, ConfigType, destinations)
 	StaleFiles    []string // old file paths that should be removed after writing the new format
+}
+
+// updateVarsMap holds per-config update variables in memory only. Values are
+// sensitive (passwords, tokens) and must never be persisted to disk or sent
+// back to the server. Replaced wholesale on every successful poll so revoked
+// credentials don't linger.
+var (
+	updateVarsMu  sync.Mutex
+	updateVarsMap = map[string][]api.UpdateVariable{}
+)
+
+func setUpdateVariables(byID map[string][]api.UpdateVariable) {
+	updateVarsMu.Lock()
+	defer updateVarsMu.Unlock()
+	if byID == nil {
+		updateVarsMap = map[string][]api.UpdateVariable{}
+		return
+	}
+	updateVarsMap = byID
+}
+
+func getUpdateVariables(configID string) []api.UpdateVariable {
+	updateVarsMu.Lock()
+	defer updateVarsMu.Unlock()
+	return updateVarsMap[configID]
 }
 
 func PollAndSync(forceSync bool) {
@@ -83,6 +109,8 @@ func PollForConfiguration() (configChanges map[string]ConfigChange, err error) {
 		// No changes from the poll response
 		return nil, nil
 	}
+
+	setUpdateVariables(response.VariablesByConfigId)
 
 	if response.UpdateAvailable != nil {
 		selfupdate.SignalUpdateAvailable(

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -29,20 +29,20 @@ type ConfigChange struct {
 // credentials don't linger.
 var (
 	updateVarsMu  sync.Mutex
-	updateVarsMap = map[string][]api.UpdateVariable{}
+	updateVarsMap = map[string][]utils.UpdateVariable{}
 )
 
-func setUpdateVariables(byID map[string][]api.UpdateVariable) {
+func setUpdateVariables(byID map[string][]utils.UpdateVariable) {
 	updateVarsMu.Lock()
 	defer updateVarsMu.Unlock()
 	if byID == nil {
-		updateVarsMap = map[string][]api.UpdateVariable{}
+		updateVarsMap = map[string][]utils.UpdateVariable{}
 		return
 	}
 	updateVarsMap = byID
 }
 
-func getUpdateVariables(configID string) []api.UpdateVariable {
+func getUpdateVariables(configID string) []utils.UpdateVariable {
 	updateVarsMu.Lock()
 	defer updateVarsMu.Unlock()
 	return updateVarsMap[configID]

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -49,7 +49,7 @@ func getUpdateVariables(configID string) []utils.UpdateVariable {
 }
 
 func PollAndSync(forceSync bool) {
-	configChanges, err := PollForConfiguration()
+	configChanges, err := PollForConfiguration(forceSync)
 	if err != nil {
 		reportAgentError(err, "", "")
 		return
@@ -94,8 +94,8 @@ func DoRegistration() {
 	SendInventory()
 }
 
-func PollForConfiguration() (configChanges map[string]ConfigChange, err error) {
-	response, err := api.PollForConfiguration()
+func PollForConfiguration(forceSync bool) (configChanges map[string]ConfigChange, err error) {
+	response, err := api.PollForConfiguration(forceSync)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func PollForConfiguration() (configChanges map[string]ConfigChange, err error) {
 		log.Printf("Lock requested. Agent now locked. Lock file created at %s", config.LockFilePath(config.CurrentPath))
 
 		// Immediately re-poll once so the server sees is_locked=true in the normal loop.
-		_, err := api.PollForConfiguration()
+		_, err := api.PollForConfiguration(false)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
 )
 
@@ -246,5 +247,54 @@ func TestDetectChangedConfigs_EmptyIncomingListReturnsEmptyMap(t *testing.T) {
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty map for empty incoming, got %d entries", len(result))
+	}
+}
+
+func TestUpdateVariableStoreRoundTripAndReplace(t *testing.T) {
+	t.Cleanup(func() { setUpdateVariables(nil) })
+
+	setUpdateVariables(map[string][]api.UpdateVariable{
+		"cfg-a": {{Name: "DB_PASSWORD", Value: "hunter2"}},
+		"cfg-b": {{Name: "API_TOKEN", Value: "tok"}},
+	})
+
+	if got := getUpdateVariables("cfg-a"); len(got) != 1 || got[0].Value != "hunter2" {
+		t.Fatalf("cfg-a roundtrip failed: %+v", got)
+	}
+	if got := getUpdateVariables("missing"); got != nil {
+		t.Fatalf("missing key should return nil, got %+v", got)
+	}
+
+	// Replace wholesale — cfg-a must disappear because the new map omits it.
+	setUpdateVariables(map[string][]api.UpdateVariable{
+		"cfg-b": {{Name: "API_TOKEN", Value: "rotated"}},
+	})
+	if got := getUpdateVariables("cfg-a"); got != nil {
+		t.Fatalf("cfg-a should be gone after replace, got %+v", got)
+	}
+	if got := getUpdateVariables("cfg-b"); len(got) != 1 || got[0].Value != "rotated" {
+		t.Fatalf("cfg-b should reflect rotated value, got %+v", got)
+	}
+
+	// nil clears — required so a poll response with no vars wipes the store.
+	setUpdateVariables(nil)
+	if got := getUpdateVariables("cfg-b"); got != nil {
+		t.Fatalf("nil setter should clear, got %+v", got)
+	}
+}
+
+func TestIsValidVariableName(t *testing.T) {
+	good := []string{"DB", "_X", "DB_PASSWORD", "x9", "_0", "Mixed_Case_99"}
+	bad := []string{"", "9LEAD", "FOO BAR", "FOO;rm", "FOO-BAR", "FOO$", "FOO\nBAR"}
+
+	for _, name := range good {
+		if !isValidVariableName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+	for _, name := range bad {
+		if isValidVariableName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
+	"github.com/certkit-io/certkit-agent/utils"
 )
 
 func timePtr(t time.Time) *time.Time { return &t }
@@ -253,7 +253,7 @@ func TestDetectChangedConfigs_EmptyIncomingListReturnsEmptyMap(t *testing.T) {
 func TestUpdateVariableStoreRoundTripAndReplace(t *testing.T) {
 	t.Cleanup(func() { setUpdateVariables(nil) })
 
-	setUpdateVariables(map[string][]api.UpdateVariable{
+	setUpdateVariables(map[string][]utils.UpdateVariable{
 		"cfg-a": {{Name: "DB_PASSWORD", Value: "hunter2"}},
 		"cfg-b": {{Name: "API_TOKEN", Value: "tok"}},
 	})
@@ -266,7 +266,7 @@ func TestUpdateVariableStoreRoundTripAndReplace(t *testing.T) {
 	}
 
 	// Replace wholesale — cfg-a must disappear because the new map omits it.
-	setUpdateVariables(map[string][]api.UpdateVariable{
+	setUpdateVariables(map[string][]utils.UpdateVariable{
 		"cfg-b": {{Name: "API_TOKEN", Value: "rotated"}},
 	})
 	if got := getUpdateVariables("cfg-a"); got != nil {
@@ -283,18 +283,3 @@ func TestUpdateVariableStoreRoundTripAndReplace(t *testing.T) {
 	}
 }
 
-func TestIsValidVariableName(t *testing.T) {
-	good := []string{"DB", "_X", "DB_PASSWORD", "x9", "_0", "Mixed_Case_99"}
-	bad := []string{"", "9LEAD", "FOO BAR", "FOO;rm", "FOO-BAR", "FOO$", "FOO\nBAR"}
-
-	for _, name := range good {
-		if !isValidVariableName(name) {
-			t.Errorf("expected %q to be valid", name)
-		}
-	}
-	for _, name := range bad {
-		if isValidVariableName(name) {
-			t.Errorf("expected %q to be invalid", name)
-		}
-	}
-}

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -221,7 +221,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 			}
 			if commandOutput, err := runUpdateCommand(cfg, getUpdateVariables(cfg.Id)); err != nil {
 				status.Status = statusErrorUpdateCmd
-				status.Message = fmt.Sprintf("Error running update command: %v", err)
+				status.Message = fmt.Sprintf("%v\n%v", err, commandOutput)
 				return status
 			} else {
 				status.Message = fmt.Sprintf("Update command output: \n%s", commandOutput)

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -294,12 +294,13 @@ func needsCertificateFetch(cfg config.CertificateConfiguration) (bool, error) {
 			return true, nil
 		}
 
-		actualSha1, err := utils.GetCertificateSha1FromPfx(cfg.PemDestination, string(passwordBytes))
+		match, err := utils.DoesPfxContainSha1(cfg.PemDestination, string(passwordBytes), cfg.LatestCertificateSha1)
 		if err != nil {
-			log.Printf("Failed to read certificate SHA1 from PFX %s: %v (forcing fetch)", cfg.PemDestination, err)
+			log.Printf("Failed to read certificates from PFX %s: %v (forcing fetch)", cfg.PemDestination, err)
 			return true, nil
 		}
-		if !strings.EqualFold(actualSha1, cfg.LatestCertificateSha1) {
+		if !match {
+			log.Printf("PFX does not contain expected SHA1 %s (forcing fetch)", cfg.LatestCertificateSha1)
 			return true, nil
 		}
 
@@ -653,4 +654,3 @@ func resolveGroupId(name string) (int, error) {
 	}
 	return gid, nil
 }
-

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -219,7 +219,7 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 			} else if (retryUpdateOnly || retryFull) && cfg.LastStatus == statusWaitingWindow {
 				log.Print("Running update command inside deploy window...")
 			}
-			if commandOutput, err := runUpdateCommand(cfg); err != nil {
+			if commandOutput, err := runUpdateCommand(cfg, getUpdateVariables(cfg.Id)); err != nil {
 				status.Status = statusErrorUpdateCmd
 				status.Message = fmt.Sprintf("Error running update command: %v", err)
 				return status
@@ -652,4 +652,24 @@ func resolveGroupId(name string) (int, error) {
 		return 0, fmt.Errorf("parse gid for group %q: %w", name, err)
 	}
 	return gid, nil
+}
+
+// isValidVariableName matches [A-Za-z_][A-Za-z0-9_]* — defense in depth so a
+// malformed variable name from the server cannot inject shell or PowerShell
+// syntax via the assignment line.
+func isValidVariableName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -654,22 +654,3 @@ func resolveGroupId(name string) (int, error) {
 	return gid, nil
 }
 
-// isValidVariableName matches [A-Za-z_][A-Za-z0-9_]* — defense in depth so a
-// malformed variable name from the server cannot inject shell or PowerShell
-// syntax via the assignment line.
-func isValidVariableName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		switch {
-		case r == '_':
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case i > 0 && r >= '0' && r <= '9':
-		default:
-			return false
-		}
-	}
-	return true
-}

--- a/agent/synchronize_update_cmd_other.go
+++ b/agent/synchronize_update_cmd_other.go
@@ -8,17 +8,20 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
+	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func runUpdateCommand(cfg config.CertificateConfiguration, vars []api.UpdateVariable) (output string, err error) {
+func runUpdateCommand(cfg config.CertificateConfiguration, vars []utils.UpdateVariable) (output string, err error) {
 	if strings.TrimSpace(cfg.UpdateCmd) == "" {
 		return "", nil
 	}
 
 	interpreter, preamble := pickShellPreamble()
-	script, appliedVarCount := buildShellScript(preamble, cfg.UpdateCmd, vars, cfg.Id)
+	script, appliedVarCount := buildShellScript(preamble, cfg.UpdateCmd, vars)
+	if dropped := len(vars) - appliedVarCount; dropped > 0 {
+		log.Printf("Dropped %d update variables with invalid names for config %s", dropped, cfg.Id)
+	}
 
 	log.Printf("Running update command for config %s (interpreter=%s, vars=%d)", cfg.Id, interpreter, appliedVarCount)
 
@@ -45,23 +48,20 @@ func pickShellPreamble() (interpreter, preamble string) {
 
 // buildShellScript composes the script piped to bash/sh: preamble, then one
 // `export NAME='VALUE'` per validated variable, then the user's update_cmd
-// verbatim. The returned int is the count of variables actually injected
-// (invalid names are skipped). Pure helper for testability.
-func buildShellScript(preamble, updateCmd string, vars []api.UpdateVariable, configID string) (string, int) {
+// verbatim. Variables whose names don't match [A-Za-z_][A-Za-z0-9_]* are
+// silently skipped — defense in depth against shell injection via the
+// assignment line. Returns the full script and the count of variables
+// actually injected.
+func buildShellScript(preamble, updateCmd string, vars []utils.UpdateVariable) (string, int) {
 	var b strings.Builder
 	b.WriteString(preamble)
 
 	appliedVarCount := 0
 	for _, v := range vars {
-		if !isValidVariableName(v.Name) {
-			log.Printf("Skipping update variable with invalid name for config %s", configID)
+		if !utils.IsValidVariableName(v.Name) {
 			continue
 		}
-		b.WriteString("export ")
-		b.WriteString(v.Name)
-		b.WriteString("='")
-		b.WriteString(escapeShellSingleQuoted(v.Value))
-		b.WriteString("'\n")
+		fmt.Fprintf(&b, "export %s='%s'\n", v.Name, escapeShellSingleQuoted(v.Value))
 		appliedVarCount++
 	}
 

--- a/agent/synchronize_update_cmd_other.go
+++ b/agent/synchronize_update_cmd_other.go
@@ -33,7 +33,7 @@ func runUpdateCommand(cfg config.CertificateConfiguration, vars []utils.UpdateVa
 		log.Printf("Update command output for config %s:\n%s", cfg.Id, string(combinedOutput))
 	}
 	if err != nil {
-		return string(combinedOutput), fmt.Errorf("Update command failed: \n%w\n%s", err, string(combinedOutput))
+		return string(combinedOutput), fmt.Errorf("update command failed: %w", err)
 	}
 
 	return string(combinedOutput), nil

--- a/agent/synchronize_update_cmd_other.go
+++ b/agent/synchronize_update_cmd_other.go
@@ -8,25 +8,75 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
 )
 
-func runUpdateCommand(cfg config.CertificateConfiguration) (output string, err error) {
+func runUpdateCommand(cfg config.CertificateConfiguration, vars []api.UpdateVariable) (output string, err error) {
 	if strings.TrimSpace(cfg.UpdateCmd) == "" {
 		return "", nil
 	}
 
-	log.Printf("Running update command: '%s'", cfg.UpdateCmd)
+	interpreter, preamble := pickShellPreamble()
+	script, appliedVarCount := buildShellScript(preamble, cfg.UpdateCmd, vars, cfg.Id)
 
-	cmd := exec.Command("sh", "-c", cfg.UpdateCmd)
+	log.Printf("Running update command for config %s (interpreter=%s, vars=%d)", cfg.Id, interpreter, appliedVarCount)
+
+	cmd := exec.Command(interpreter, "-s")
+	cmd.Stdin = strings.NewReader(script)
 
 	combinedOutput, err := cmd.CombinedOutput()
 	if len(combinedOutput) > 0 {
-		log.Printf("Update command output for '%s':\n%s", cfg.UpdateCmd, string(combinedOutput))
+		log.Printf("Update command output for config %s:\n%s", cfg.Id, string(combinedOutput))
 	}
 	if err != nil {
 		return string(combinedOutput), fmt.Errorf("Update command failed: \n%w\n%s", err, string(combinedOutput))
 	}
 
 	return string(combinedOutput), nil
+}
+
+func pickShellPreamble() (interpreter, preamble string) {
+	if _, err := exec.LookPath("bash"); err == nil {
+		return "bash", "set -euo pipefail\n"
+	}
+	return "sh", "set -eu\n"
+}
+
+// buildShellScript composes the script piped to bash/sh: preamble, then one
+// `export NAME='VALUE'` per validated variable, then the user's update_cmd
+// verbatim. The returned int is the count of variables actually injected
+// (invalid names are skipped). Pure helper for testability.
+func buildShellScript(preamble, updateCmd string, vars []api.UpdateVariable, configID string) (string, int) {
+	var b strings.Builder
+	b.WriteString(preamble)
+
+	appliedVarCount := 0
+	for _, v := range vars {
+		if !isValidVariableName(v.Name) {
+			log.Printf("Skipping update variable with invalid name for config %s", configID)
+			continue
+		}
+		b.WriteString("export ")
+		b.WriteString(v.Name)
+		b.WriteString("='")
+		b.WriteString(escapeShellSingleQuoted(v.Value))
+		b.WriteString("'\n")
+		appliedVarCount++
+	}
+
+	b.WriteString(updateCmd)
+	if !strings.HasSuffix(updateCmd, "\n") {
+		b.WriteString("\n")
+	}
+
+	return b.String(), appliedVarCount
+}
+
+// escapeShellSingleQuoted escapes a value for inclusion inside a POSIX
+// single-quoted string. The only character that ends a single-quoted string
+// is another single quote; the standard idiom is to close, emit an escaped
+// single quote, then reopen.
+func escapeShellSingleQuoted(value string) string {
+	return strings.ReplaceAll(value, "'", `'\''`)
 }

--- a/agent/synchronize_update_cmd_other_test.go
+++ b/agent/synchronize_update_cmd_other_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/utils"
 )
 
 func TestBuildShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
-	script, count := buildShellScript("set -euo pipefail\n", "echo hi", nil, "cfg-a")
+	script, count := buildShellScript("set -euo pipefail\n", "echo hi", nil)
 
 	if count != 0 {
 		t.Fatalf("expected 0 vars applied, got %d", count)
@@ -23,7 +23,7 @@ func TestBuildShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
 
 func TestBuildShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T) {
 	updateCmd := "set\nfor i in 1 2 3; do\n  echo $i\ndone"
-	script, _ := buildShellScript("set -eu\n", updateCmd, nil, "cfg-a")
+	script, _ := buildShellScript("set -eu\n", updateCmd, nil)
 
 	if !strings.Contains(script, updateCmd) {
 		t.Fatalf("multiline update_cmd was modified during script build:\n%s", script)
@@ -34,10 +34,10 @@ func TestBuildShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T) {
 }
 
 func TestBuildShellScript_EscapesSingleQuotesInValue(t *testing.T) {
-	vars := []api.UpdateVariable{
+	vars := []utils.UpdateVariable{
 		{Name: "PW", Value: "it's a secret"},
 	}
-	script, count := buildShellScript("set -eu\n", "echo $PW", vars, "cfg-a")
+	script, count := buildShellScript("set -eu\n", "echo $PW", vars)
 
 	if count != 1 {
 		t.Fatalf("expected 1 var applied, got %d", count)
@@ -50,13 +50,13 @@ func TestBuildShellScript_EscapesSingleQuotesInValue(t *testing.T) {
 }
 
 func TestBuildShellScript_SkipsInvalidVariableNames(t *testing.T) {
-	vars := []api.UpdateVariable{
+	vars := []utils.UpdateVariable{
 		{Name: "GOOD", Value: "1"},
 		{Name: "BAD NAME", Value: "2"},
 		{Name: "9LEAD", Value: "3"},
 		{Name: "PW", Value: "4"},
 	}
-	script, count := buildShellScript("set -eu\n", "echo done", vars, "cfg-a")
+	script, count := buildShellScript("set -eu\n", "echo done", vars)
 
 	if count != 2 {
 		t.Fatalf("expected 2 valid vars applied, got %d", count)

--- a/agent/synchronize_update_cmd_other_test.go
+++ b/agent/synchronize_update_cmd_other_test.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/certkit-io/certkit-agent/api"
+)
+
+func TestBuildShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
+	script, count := buildShellScript("set -euo pipefail\n", "echo hi", nil, "cfg-a")
+
+	if count != 0 {
+		t.Fatalf("expected 0 vars applied, got %d", count)
+	}
+	want := "set -euo pipefail\necho hi\n"
+	if script != want {
+		t.Fatalf("script mismatch:\n got: %q\nwant: %q", script, want)
+	}
+}
+
+func TestBuildShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T) {
+	updateCmd := "set\nfor i in 1 2 3; do\n  echo $i\ndone"
+	script, _ := buildShellScript("set -eu\n", updateCmd, nil, "cfg-a")
+
+	if !strings.Contains(script, updateCmd) {
+		t.Fatalf("multiline update_cmd was modified during script build:\n%s", script)
+	}
+	if !strings.HasSuffix(script, "\n") {
+		t.Fatalf("script must end with newline:\n%s", script)
+	}
+}
+
+func TestBuildShellScript_EscapesSingleQuotesInValue(t *testing.T) {
+	vars := []api.UpdateVariable{
+		{Name: "PW", Value: "it's a secret"},
+	}
+	script, count := buildShellScript("set -eu\n", "echo $PW", vars, "cfg-a")
+
+	if count != 1 {
+		t.Fatalf("expected 1 var applied, got %d", count)
+	}
+	// Standard POSIX single-quote escape: close, escaped quote, reopen.
+	wantLine := `export PW='it'\''s a secret'`
+	if !strings.Contains(script, wantLine) {
+		t.Fatalf("expected escaped single-quote line %q in script:\n%s", wantLine, script)
+	}
+}
+
+func TestBuildShellScript_SkipsInvalidVariableNames(t *testing.T) {
+	vars := []api.UpdateVariable{
+		{Name: "GOOD", Value: "1"},
+		{Name: "BAD NAME", Value: "2"},
+		{Name: "9LEAD", Value: "3"},
+		{Name: "PW", Value: "4"},
+	}
+	script, count := buildShellScript("set -eu\n", "echo done", vars, "cfg-a")
+
+	if count != 2 {
+		t.Fatalf("expected 2 valid vars applied, got %d", count)
+	}
+	if !strings.Contains(script, "export GOOD='1'\n") || !strings.Contains(script, "export PW='4'\n") {
+		t.Fatalf("expected valid vars in script:\n%s", script)
+	}
+	if strings.Contains(script, "BAD NAME") || strings.Contains(script, "9LEAD") {
+		t.Fatalf("invalid var name leaked into script:\n%s", script)
+	}
+}

--- a/agent/synchronize_update_cmd_windows.go
+++ b/agent/synchronize_update_cmd_windows.go
@@ -7,17 +7,19 @@ import (
 	"log"
 	"strings"
 
-	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func runUpdateCommand(cfg config.CertificateConfiguration, vars []api.UpdateVariable) (output string, err error) {
+func runUpdateCommand(cfg config.CertificateConfiguration, vars []utils.UpdateVariable) (output string, err error) {
 	if strings.TrimSpace(cfg.UpdateCmd) == "" {
 		return "", nil
 	}
 
-	script, appliedVarCount := buildPowerShellScript(cfg.UpdateCmd, vars, cfg.Id)
+	script, appliedVarCount := utils.BuildPowerShellScript(cfg.UpdateCmd, vars, "")
+	if dropped := len(vars) - appliedVarCount; dropped > 0 {
+		log.Printf("Dropped %d update variables with invalid names for config %s", dropped, cfg.Id)
+	}
 
 	log.Printf("Running update command for config %s (vars=%d)", cfg.Id, appliedVarCount)
 
@@ -30,35 +32,4 @@ func runUpdateCommand(cfg config.CertificateConfiguration, vars []api.UpdateVari
 	}
 
 	return out, nil
-}
-
-// buildPowerShellScript composes the script piped to powershell.exe via stdin:
-// the $ErrorActionPreference fail-fast preamble, then one `$NAME = 'VALUE'`
-// per validated variable, then the user's update_cmd verbatim. The returned
-// int is the count of variables actually injected (invalid names are skipped).
-// Pure helper for testability.
-func buildPowerShellScript(updateCmd string, vars []api.UpdateVariable, configID string) (string, int) {
-	var b strings.Builder
-	b.WriteString("$ErrorActionPreference = 'Stop'\n")
-
-	appliedVarCount := 0
-	for _, v := range vars {
-		if !isValidVariableName(v.Name) {
-			log.Printf("Skipping update variable with invalid name for config %s", configID)
-			continue
-		}
-		b.WriteString("$")
-		b.WriteString(v.Name)
-		b.WriteString(" = '")
-		b.WriteString(escapePowerShellString(v.Value))
-		b.WriteString("'\n")
-		appliedVarCount++
-	}
-
-	b.WriteString(updateCmd)
-	if !strings.HasSuffix(updateCmd, "\n") {
-		b.WriteString("\n")
-	}
-
-	return b.String(), appliedVarCount
 }

--- a/agent/synchronize_update_cmd_windows.go
+++ b/agent/synchronize_update_cmd_windows.go
@@ -7,24 +7,58 @@ import (
 	"log"
 	"strings"
 
+	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
 	"github.com/certkit-io/certkit-agent/utils"
 )
 
-func runUpdateCommand(cfg config.CertificateConfiguration) (output string, err error) {
+func runUpdateCommand(cfg config.CertificateConfiguration, vars []api.UpdateVariable) (output string, err error) {
 	if strings.TrimSpace(cfg.UpdateCmd) == "" {
 		return "", nil
 	}
 
-	log.Printf("Running update command: '%s'", cfg.UpdateCmd)
+	script, appliedVarCount := buildPowerShellScript(cfg.UpdateCmd, vars, cfg.Id)
 
-	out, err := utils.RunPowerShell(cfg.UpdateCmd)
+	log.Printf("Running update command for config %s (vars=%d)", cfg.Id, appliedVarCount)
+
+	out, err := utils.RunPowerShellViaStdin(script)
 	if out != "" {
-		log.Printf("Update command output for '%s':\n%s", cfg.UpdateCmd, out)
+		log.Printf("Update command output for config %s:\n%s", cfg.Id, out)
 	}
 	if err != nil {
 		return out, fmt.Errorf("Update command failed: \n%w\n%s", err, out)
 	}
 
 	return out, nil
+}
+
+// buildPowerShellScript composes the script piped to powershell.exe via stdin:
+// the $ErrorActionPreference fail-fast preamble, then one `$NAME = 'VALUE'`
+// per validated variable, then the user's update_cmd verbatim. The returned
+// int is the count of variables actually injected (invalid names are skipped).
+// Pure helper for testability.
+func buildPowerShellScript(updateCmd string, vars []api.UpdateVariable, configID string) (string, int) {
+	var b strings.Builder
+	b.WriteString("$ErrorActionPreference = 'Stop'\n")
+
+	appliedVarCount := 0
+	for _, v := range vars {
+		if !isValidVariableName(v.Name) {
+			log.Printf("Skipping update variable with invalid name for config %s", configID)
+			continue
+		}
+		b.WriteString("$")
+		b.WriteString(v.Name)
+		b.WriteString(" = '")
+		b.WriteString(escapePowerShellString(v.Value))
+		b.WriteString("'\n")
+		appliedVarCount++
+	}
+
+	b.WriteString(updateCmd)
+	if !strings.HasSuffix(updateCmd, "\n") {
+		b.WriteString("\n")
+	}
+
+	return b.String(), appliedVarCount
 }

--- a/agent/synchronize_update_cmd_windows.go
+++ b/agent/synchronize_update_cmd_windows.go
@@ -28,7 +28,7 @@ func runUpdateCommand(cfg config.CertificateConfiguration, vars []utils.UpdateVa
 		log.Printf("Update command output for config %s:\n%s", cfg.Id, out)
 	}
 	if err != nil {
-		return out, fmt.Errorf("Update command failed: \n%w\n%s", err, out)
+		return out, fmt.Errorf("update command failed: %w", err)
 	}
 
 	return out, nil

--- a/agent/synchronize_update_cmd_windows_test.go
+++ b/agent/synchronize_update_cmd_windows_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/certkit-io/certkit-agent/api"
+)
+
+func TestBuildPowerShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
+	script, count := buildPowerShellScript("Write-Host hi", nil, "cfg-a")
+
+	if count != 0 {
+		t.Fatalf("expected 0 vars applied, got %d", count)
+	}
+	want := "$ErrorActionPreference = 'Stop'\nWrite-Host hi\n"
+	if script != want {
+		t.Fatalf("script mismatch:\n got: %q\nwant: %q", script, want)
+	}
+}
+
+func TestBuildPowerShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T) {
+	updateCmd := "Write-Host one\nforeach ($i in 1..3) {\n  Write-Host $i\n}"
+	script, _ := buildPowerShellScript(updateCmd, nil, "cfg-a")
+
+	if !strings.Contains(script, updateCmd) {
+		t.Fatalf("multiline update_cmd was modified during script build:\n%s", script)
+	}
+	if !strings.HasSuffix(script, "\n") {
+		t.Fatalf("script must end with newline:\n%s", script)
+	}
+}
+
+func TestBuildPowerShellScript_EscapesSingleQuotesInValue(t *testing.T) {
+	vars := []api.UpdateVariable{
+		{Name: "PW", Value: "it's a secret"},
+	}
+	script, count := buildPowerShellScript("Write-Host $PW", vars, "cfg-a")
+
+	if count != 1 {
+		t.Fatalf("expected 1 var applied, got %d", count)
+	}
+	// PowerShell single-quoted strings double-up `'` to escape.
+	wantLine := "$PW = 'it''s a secret'"
+	if !strings.Contains(script, wantLine) {
+		t.Fatalf("expected escaped single-quote line %q in script:\n%s", wantLine, script)
+	}
+}
+
+func TestBuildPowerShellScript_SkipsInvalidVariableNames(t *testing.T) {
+	vars := []api.UpdateVariable{
+		{Name: "GOOD", Value: "1"},
+		{Name: "BAD NAME", Value: "2"},
+		{Name: "9LEAD", Value: "3"},
+		{Name: "PW", Value: "4"},
+	}
+	script, count := buildPowerShellScript("Write-Host done", vars, "cfg-a")
+
+	if count != 2 {
+		t.Fatalf("expected 2 valid vars applied, got %d", count)
+	}
+	if !strings.Contains(script, "$GOOD = '1'\n") || !strings.Contains(script, "$PW = '4'\n") {
+		t.Fatalf("expected valid vars in script:\n%s", script)
+	}
+	if strings.Contains(script, "BAD NAME") || strings.Contains(script, "9LEAD") {
+		t.Fatalf("invalid var name leaked into script:\n%s", script)
+	}
+}
+
+func TestBuildWindowsCertStoreScript_OrderingAndCertLoad(t *testing.T) {
+	vars := []api.UpdateVariable{
+		{Name: "PW", Value: "secret"},
+	}
+	script, count := buildWindowsCertStoreScript("ABC123", "Write-Host $PW $thumbprint", vars)
+
+	if count != 1 {
+		t.Fatalf("expected 1 var applied, got %d", count)
+	}
+
+	idxPreamble := strings.Index(script, "$ErrorActionPreference = 'Stop'")
+	idxVar := strings.Index(script, "$PW = 'secret'")
+	idxCert := strings.Index(script, "$certificate = Get-Item")
+	idxUserCmd := strings.Index(script, "Write-Host $PW $thumbprint")
+
+	if idxPreamble < 0 || idxVar < 0 || idxCert < 0 || idxUserCmd < 0 {
+		t.Fatalf("missing expected lines:\n%s", script)
+	}
+
+	// Order must be: preamble → vars → cert load → user cmd
+	if !(idxPreamble < idxVar && idxVar < idxCert && idxCert < idxUserCmd) {
+		t.Fatalf("script ordering wrong (preamble=%d vars=%d cert=%d user=%d):\n%s",
+			idxPreamble, idxVar, idxCert, idxUserCmd, script)
+	}
+}

--- a/agent/synchronize_windows_cert_store_windows.go
+++ b/agent/synchronize_windows_cert_store_windows.go
@@ -20,7 +20,7 @@ func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration,
 				log.Print("No update command configured; skipping update command.")
 				return "", nil
 			}
-			out, err := runWindowsCertStoreUpdateCmd(thumbprint, cfg.UpdateCmd)
+			out, err := runWindowsCertStoreUpdateCmd(thumbprint, cfg.UpdateCmd, getUpdateVariables(cfg.Id))
 			if err != nil {
 				return "", err
 			}
@@ -32,22 +32,55 @@ func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration,
 	})
 }
 
-func runWindowsCertStoreUpdateCmd(thumbprint, updateCmd string) (string, error) {
+func runWindowsCertStoreUpdateCmd(thumbprint, updateCmd string, vars []api.UpdateVariable) (string, error) {
 	thumbprint = normalizeThumbprint(thumbprint)
 	if thumbprint == "" {
 		return "", fmt.Errorf("missing thumbprint for update command")
 	}
 
-	script := fmt.Sprintf(`
-$ErrorActionPreference = 'Stop'
-$thumbprint = '%s'
-$certificate = Get-Item "Cert:\LocalMachine\My\$thumbprint" -ErrorAction Stop
+	script, appliedVarCount := buildWindowsCertStoreScript(thumbprint, updateCmd, vars)
 
-%s
-`, escapePowerShellString(thumbprint), updateCmd)
-
-	log.Printf("Running windows-cert-store update command: '%s'", updateCmd)
-	out, err := utils.RunPowerShell(script)
+	log.Printf("Running windows-cert-store update command (vars=%d)", appliedVarCount)
+	out, err := utils.RunPowerShellViaStdin(script)
 	logPowerShellOutput("runWindowsCertStoreUpdateCmd", out)
 	return out, err
+}
+
+// buildWindowsCertStoreScript composes the PowerShell script for the
+// windows-cert-store config type:
+//  1. $ErrorActionPreference = 'Stop' fail-fast preamble.
+//  2. One `$NAME = 'VALUE'` per validated user variable.
+//  3. Cert-load convenience block exposing $thumbprint and $certificate.
+//  4. The user's update_cmd verbatim.
+//
+// Variables go before the cert-load block so the briefing's "shoved at the
+// top" intent is honored; the cert convenience is system-injected and sits
+// just before the user command so the user can reference both.
+func buildWindowsCertStoreScript(thumbprint, updateCmd string, vars []api.UpdateVariable) (string, int) {
+	var b strings.Builder
+	b.WriteString("$ErrorActionPreference = 'Stop'\n")
+
+	appliedVarCount := 0
+	for _, v := range vars {
+		if !isValidVariableName(v.Name) {
+			log.Printf("Skipping update variable with invalid name for windows-cert-store update")
+			continue
+		}
+		b.WriteString("$")
+		b.WriteString(v.Name)
+		b.WriteString(" = '")
+		b.WriteString(escapePowerShellString(v.Value))
+		b.WriteString("'\n")
+		appliedVarCount++
+	}
+
+	fmt.Fprintf(&b, "$thumbprint = '%s'\n", escapePowerShellString(thumbprint))
+	b.WriteString("$certificate = Get-Item \"Cert:\\LocalMachine\\My\\$thumbprint\" -ErrorAction Stop\n")
+
+	b.WriteString(updateCmd)
+	if !strings.HasSuffix(updateCmd, "\n") {
+		b.WriteString("\n")
+	}
+
+	return b.String(), appliedVarCount
 }

--- a/agent/synchronize_windows_cert_store_windows.go
+++ b/agent/synchronize_windows_cert_store_windows.go
@@ -20,7 +20,7 @@ func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration,
 				log.Print("No update command configured; skipping update command.")
 				return "", nil
 			}
-			out, err := runWindowsCertStoreUpdateCmd(thumbprint, cfg.UpdateCmd, getUpdateVariables(cfg.Id))
+			out, err := runWindowsCertStoreUpdateCmd(cfg.Id, thumbprint, cfg.UpdateCmd, getUpdateVariables(cfg.Id))
 			if err != nil {
 				return "", err
 			}
@@ -32,55 +32,26 @@ func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration,
 	})
 }
 
-func runWindowsCertStoreUpdateCmd(thumbprint, updateCmd string, vars []api.UpdateVariable) (string, error) {
+// runWindowsCertStoreUpdateCmd runs the user's update_cmd for the
+// windows-cert-store config type. The system-injected block exposes
+// $thumbprint and $certificate so the user's command can reference both.
+func runWindowsCertStoreUpdateCmd(configID, thumbprint, updateCmd string, vars []utils.UpdateVariable) (string, error) {
 	thumbprint = normalizeThumbprint(thumbprint)
 	if thumbprint == "" {
 		return "", fmt.Errorf("missing thumbprint for update command")
 	}
 
-	script, appliedVarCount := buildWindowsCertStoreScript(thumbprint, updateCmd, vars)
+	var certLoad strings.Builder
+	fmt.Fprintf(&certLoad, "$thumbprint = '%s'\n", escapePowerShellString(thumbprint))
+	certLoad.WriteString("$certificate = Get-Item \"Cert:\\LocalMachine\\My\\$thumbprint\" -ErrorAction Stop\n")
 
-	log.Printf("Running windows-cert-store update command (vars=%d)", appliedVarCount)
+	script, appliedVarCount := utils.BuildPowerShellScript(updateCmd, vars, certLoad.String())
+	if dropped := len(vars) - appliedVarCount; dropped > 0 {
+		log.Printf("Dropped %d update variables with invalid names for config %s", dropped, configID)
+	}
+
+	log.Printf("Running windows-cert-store update command for config %s (vars=%d)", configID, appliedVarCount)
 	out, err := utils.RunPowerShellViaStdin(script)
 	logPowerShellOutput("runWindowsCertStoreUpdateCmd", out)
 	return out, err
-}
-
-// buildWindowsCertStoreScript composes the PowerShell script for the
-// windows-cert-store config type:
-//  1. $ErrorActionPreference = 'Stop' fail-fast preamble.
-//  2. One `$NAME = 'VALUE'` per validated user variable.
-//  3. Cert-load convenience block exposing $thumbprint and $certificate.
-//  4. The user's update_cmd verbatim.
-//
-// Variables go before the cert-load block so the briefing's "shoved at the
-// top" intent is honored; the cert convenience is system-injected and sits
-// just before the user command so the user can reference both.
-func buildWindowsCertStoreScript(thumbprint, updateCmd string, vars []api.UpdateVariable) (string, int) {
-	var b strings.Builder
-	b.WriteString("$ErrorActionPreference = 'Stop'\n")
-
-	appliedVarCount := 0
-	for _, v := range vars {
-		if !isValidVariableName(v.Name) {
-			log.Printf("Skipping update variable with invalid name for windows-cert-store update")
-			continue
-		}
-		b.WriteString("$")
-		b.WriteString(v.Name)
-		b.WriteString(" = '")
-		b.WriteString(escapePowerShellString(v.Value))
-		b.WriteString("'\n")
-		appliedVarCount++
-	}
-
-	fmt.Fprintf(&b, "$thumbprint = '%s'\n", escapePowerShellString(thumbprint))
-	b.WriteString("$certificate = Get-Item \"Cert:\\LocalMachine\\My\\$thumbprint\" -ErrorAction Stop\n")
-
-	b.WriteString(updateCmd)
-	if !strings.HasSuffix(updateCmd, "\n") {
-		b.WriteString("\n")
-	}
-
-	return b.String(), appliedVarCount
 }

--- a/agent/synchronize_windows_cert_store_windows.go
+++ b/agent/synchronize_windows_cert_store_windows.go
@@ -41,11 +41,12 @@ func runWindowsCertStoreUpdateCmd(configID, thumbprint, updateCmd string, vars [
 		return "", fmt.Errorf("missing thumbprint for update command")
 	}
 
-	var certLoad strings.Builder
-	fmt.Fprintf(&certLoad, "$thumbprint = '%s'\n", escapePowerShellString(thumbprint))
-	certLoad.WriteString("$certificate = Get-Item \"Cert:\\LocalMachine\\My\\$thumbprint\" -ErrorAction Stop\n")
+	// Windows Cert Store gets a few extra variables
+	var windowsCertStoreSpecificScriptInjection strings.Builder
+	fmt.Fprintf(&windowsCertStoreSpecificScriptInjection, "$thumbprint = '%s'\n", escapePowerShellString(thumbprint))
+	windowsCertStoreSpecificScriptInjection.WriteString("$certificate = Get-Item \"Cert:\\LocalMachine\\My\\$thumbprint\" -ErrorAction Stop\n")
 
-	script, appliedVarCount := utils.BuildPowerShellScript(updateCmd, vars, certLoad.String())
+	script, appliedVarCount := utils.BuildPowerShellScript(updateCmd, vars, windowsCertStoreSpecificScriptInjection.String())
 	if dropped := len(vars) - appliedVarCount; dropped > 0 {
 		log.Printf("Dropped %d update variables with invalid names for config %s", dropped, configID)
 	}

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/certkit-io/certkit-agent/auth"
@@ -16,6 +17,7 @@ import (
 type ConfigurationPollRequest struct {
 	CertificateConfigurations []PollRequestCertificateConfig `json:"certificate_configurations"`
 	IsLocked                  bool                           `json:"is_locked"`
+	ForceFullSync             bool                           `json:"force_full_sync,omitempty"`
 }
 
 type PollRequestCertificateConfig struct {
@@ -25,17 +27,62 @@ type PollRequestCertificateConfig struct {
 	LatestCertificateSha1       string    `json:"latest_certificate_sha1"`
 }
 
+// UpdateVariable is a name/value pair injected into update_cmd execution.
+// Values are sensitive and must never be persisted to disk or sent back to the server.
+type UpdateVariable struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ConfigurationPollResponse is the agent-facing decoded poll response.
+// VariablesByConfigId is memory-only — json:"-" prevents accidental serialization.
 type ConfigurationPollResponse struct {
 	UpdatedCertificateConfigurations []config.CertificateConfiguration `json:"updated_certificate_configurations"`
 	LockRequested                    bool                              `json:"lock_requested"`
 	Keystore                         *config.KeystoreConfig            `json:"keystore,omitempty"`
 	UpdateAvailable                  *UpdateSignal                     `json:"update_available,omitempty"`
+	VariablesByConfigId              map[string][]UpdateVariable       `json:"-"`
+}
+
+// pollResponseConfig is the wire shape of an entry in updated_certificate_configurations.
+// It mirrors config.CertificateConfiguration but adds UpdateVariables, which never
+// reaches the disk-shaped CertificateConfiguration that gets persisted via SaveConfig.
+type pollResponseConfig struct {
+	config.CertificateConfiguration
+	UpdateVariables []UpdateVariable `json:"update_variables,omitempty"`
+}
+
+type pollResponseWire struct {
+	UpdatedCertificateConfigurations []pollResponseConfig   `json:"updated_certificate_configurations"`
+	LockRequested                    bool                   `json:"lock_requested"`
+	Keystore                         *config.KeystoreConfig `json:"keystore,omitempty"`
+	UpdateAvailable                  *UpdateSignal          `json:"update_available,omitempty"`
 }
 
 type UpdateSignal struct {
 	Version     string `json:"version"`
 	DownloadURL string `json:"download_url"`
 	SHA256      string `json:"sha256"`
+}
+
+// pendingForceFullSync starts true at process init. The first poll sends
+// force_full_sync=true; clearPendingForceFullSync is called after a successful
+// 200 response is fully decoded so subsequent polls revert to delta-sync.
+var (
+	forceFullSyncMu      sync.Mutex
+	pendingForceFullSync = true
+)
+
+func consumePendingForceFullSync() bool {
+	forceFullSyncMu.Lock()
+	defer forceFullSyncMu.Unlock()
+	return pendingForceFullSync
+}
+
+func clearPendingForceFullSync() {
+	forceFullSyncMu.Lock()
+	defer forceFullSyncMu.Unlock()
+	pendingForceFullSync = false
 }
 
 func PollForConfiguration() (*ConfigurationPollResponse, error) {
@@ -69,6 +116,7 @@ func PollForConfiguration() (*ConfigurationPollResponse, error) {
 	payload := ConfigurationPollRequest{
 		CertificateConfigurations: requestConfigs,
 		IsLocked:                  isLocked,
+		ForceFullSync:             consumePendingForceFullSync(),
 	}
 
 	requestBody, err := json.Marshal(payload)
@@ -125,10 +173,27 @@ func PollForConfiguration() (*ConfigurationPollResponse, error) {
 
 	utils.MarkAgentAuthorized()
 
-	var pollResp ConfigurationPollResponse
-	if err := json.Unmarshal(body, &pollResp); err != nil {
+	var wire pollResponseWire
+	if err := json.Unmarshal(body, &wire); err != nil {
 		return nil, fmt.Errorf("decode poll response: %w", err)
 	}
 
-	return &pollResp, nil
+	clearPendingForceFullSync()
+
+	configs := make([]config.CertificateConfiguration, 0, len(wire.UpdatedCertificateConfigurations))
+	varsByID := make(map[string][]UpdateVariable)
+	for _, entry := range wire.UpdatedCertificateConfigurations {
+		configs = append(configs, entry.CertificateConfiguration)
+		if entry.CertificateConfiguration.Id != "" && len(entry.UpdateVariables) > 0 {
+			varsByID[entry.CertificateConfiguration.Id] = entry.UpdateVariables
+		}
+	}
+
+	return &ConfigurationPollResponse{
+		UpdatedCertificateConfigurations: configs,
+		LockRequested:                    wire.LockRequested,
+		Keystore:                         wire.Keystore,
+		UpdateAvailable:                  wire.UpdateAvailable,
+		VariablesByConfigId:              varsByID,
+	}, nil
 }

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -27,13 +27,6 @@ type PollRequestCertificateConfig struct {
 	LatestCertificateSha1       string    `json:"latest_certificate_sha1"`
 }
 
-// UpdateVariable is a name/value pair injected into update_cmd execution.
-// Values are sensitive and must never be persisted to disk or sent back to the server.
-type UpdateVariable struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
 // ConfigurationPollResponse is the agent-facing decoded poll response.
 // VariablesByConfigId is memory-only — json:"-" prevents accidental serialization.
 type ConfigurationPollResponse struct {
@@ -41,7 +34,7 @@ type ConfigurationPollResponse struct {
 	LockRequested                    bool                              `json:"lock_requested"`
 	Keystore                         *config.KeystoreConfig            `json:"keystore,omitempty"`
 	UpdateAvailable                  *UpdateSignal                     `json:"update_available,omitempty"`
-	VariablesByConfigId              map[string][]UpdateVariable       `json:"-"`
+	VariablesByConfigId              map[string][]utils.UpdateVariable `json:"-"`
 }
 
 // pollResponseConfig is the wire shape of an entry in updated_certificate_configurations.
@@ -49,7 +42,7 @@ type ConfigurationPollResponse struct {
 // reaches the disk-shaped CertificateConfiguration that gets persisted via SaveConfig.
 type pollResponseConfig struct {
 	config.CertificateConfiguration
-	UpdateVariables []UpdateVariable `json:"update_variables,omitempty"`
+	UpdateVariables []utils.UpdateVariable `json:"update_variables,omitempty"`
 }
 
 type pollResponseWire struct {
@@ -181,7 +174,7 @@ func PollForConfiguration() (*ConfigurationPollResponse, error) {
 	clearPendingForceFullSync()
 
 	configs := make([]config.CertificateConfiguration, 0, len(wire.UpdatedCertificateConfigurations))
-	varsByID := make(map[string][]UpdateVariable)
+	varsByID := make(map[string][]utils.UpdateVariable)
 	for _, entry := range wire.UpdatedCertificateConfigurations {
 		configs = append(configs, entry.CertificateConfiguration)
 		if entry.CertificateConfiguration.Id != "" && len(entry.UpdateVariables) > 0 {

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/certkit-io/certkit-agent/auth"
@@ -58,27 +57,7 @@ type UpdateSignal struct {
 	SHA256      string `json:"sha256"`
 }
 
-// pendingForceFullSync starts true at process init. The first poll sends
-// force_full_sync=true; clearPendingForceFullSync is called after a successful
-// 200 response is fully decoded so subsequent polls revert to delta-sync.
-var (
-	forceFullSyncMu      sync.Mutex
-	pendingForceFullSync = true
-)
-
-func consumePendingForceFullSync() bool {
-	forceFullSyncMu.Lock()
-	defer forceFullSyncMu.Unlock()
-	return pendingForceFullSync
-}
-
-func clearPendingForceFullSync() {
-	forceFullSyncMu.Lock()
-	defer forceFullSyncMu.Unlock()
-	pendingForceFullSync = false
-}
-
-func PollForConfiguration() (*ConfigurationPollResponse, error) {
+func PollForConfiguration(forceFullSync bool) (*ConfigurationPollResponse, error) {
 	if config.CurrentConfig.Agent == nil || config.CurrentConfig.Agent.AgentId == "" {
 		return nil, fmt.Errorf("missing agent id")
 	}
@@ -109,7 +88,7 @@ func PollForConfiguration() (*ConfigurationPollResponse, error) {
 	payload := ConfigurationPollRequest{
 		CertificateConfigurations: requestConfigs,
 		IsLocked:                  isLocked,
-		ForceFullSync:             consumePendingForceFullSync(),
+		ForceFullSync:             forceFullSync,
 	}
 
 	requestBody, err := json.Marshal(payload)
@@ -170,8 +149,6 @@ func PollForConfiguration() (*ConfigurationPollResponse, error) {
 	if err := json.Unmarshal(body, &wire); err != nil {
 		return nil, fmt.Errorf("decode poll response: %w", err)
 	}
-
-	clearPendingForceFullSync()
 
 	configs := make([]config.CertificateConfiguration, 0, len(wire.UpdatedCertificateConfigurations))
 	varsByID := make(map[string][]utils.UpdateVariable)

--- a/api/config-poller_test.go
+++ b/api/config-poller_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPollResponseDecodeKeepsVariablesOffDiskStruct enforces the contract
+// that update_variables decodes into the in-memory VariablesByConfigId map
+// and never reaches the disk-shaped CertificateConfiguration. If a future
+// change accidentally adds UpdateVariables to config.CertificateConfiguration,
+// this test fails because the substring would appear in the re-marshaled JSON.
+func TestPollResponseDecodeKeepsVariablesOffDiskStruct(t *testing.T) {
+	body := []byte(`{
+		"updated_certificate_configurations": [
+			{
+				"config_id": "cfg-1",
+				"certificate_id": "cert-1",
+				"update_cmd": "echo hi",
+				"update_variables": [
+					{"name": "DB_PASSWORD", "value": "hunter2"},
+					{"name": "API_TOKEN",   "value": "tok"}
+				]
+			}
+		],
+		"lock_requested": false
+	}`)
+
+	resetForceFullSyncForTest()
+	defer resetForceFullSyncForTest()
+
+	var wire pollResponseWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal wire: %v", err)
+	}
+
+	if len(wire.UpdatedCertificateConfigurations) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(wire.UpdatedCertificateConfigurations))
+	}
+
+	entry := wire.UpdatedCertificateConfigurations[0]
+	if len(entry.UpdateVariables) != 2 {
+		t.Fatalf("expected 2 vars on wire entry, got %d", len(entry.UpdateVariables))
+	}
+
+	// Re-marshal the disk-shaped CertificateConfiguration and confirm it
+	// contains no trace of the variable name/value or the field key.
+	diskBytes, err := json.Marshal(entry.CertificateConfiguration)
+	if err != nil {
+		t.Fatalf("marshal disk struct: %v", err)
+	}
+	disk := string(diskBytes)
+	for _, leak := range []string{"update_variables", "DB_PASSWORD", "hunter2", "API_TOKEN", "tok"} {
+		if strings.Contains(disk, leak) {
+			t.Fatalf("disk-shaped CertificateConfiguration leaked %q: %s", leak, disk)
+		}
+	}
+}
+
+func TestForceFullSyncConsumeIsNonClearing(t *testing.T) {
+	resetForceFullSyncForTest()
+	defer resetForceFullSyncForTest()
+
+	if !consumePendingForceFullSync() {
+		t.Fatal("expected first consume to return true at process start")
+	}
+	if !consumePendingForceFullSync() {
+		t.Fatal("consume should not clear — repeated calls return true until clearPendingForceFullSync()")
+	}
+
+	clearPendingForceFullSync()
+
+	if consumePendingForceFullSync() {
+		t.Fatal("after clearPendingForceFullSync, consume must return false")
+	}
+}
+
+// resetForceFullSyncForTest restores the package-level flag so tests are
+// independent regardless of execution order.
+func resetForceFullSyncForTest() {
+	forceFullSyncMu.Lock()
+	defer forceFullSyncMu.Unlock()
+	pendingForceFullSync = true
+}

--- a/api/config-poller_test.go
+++ b/api/config-poller_test.go
@@ -27,9 +27,6 @@ func TestPollResponseDecodeKeepsVariablesOffDiskStruct(t *testing.T) {
 		"lock_requested": false
 	}`)
 
-	resetForceFullSyncForTest()
-	defer resetForceFullSyncForTest()
-
 	var wire pollResponseWire
 	if err := json.Unmarshal(body, &wire); err != nil {
 		t.Fatalf("unmarshal wire: %v", err)
@@ -58,28 +55,3 @@ func TestPollResponseDecodeKeepsVariablesOffDiskStruct(t *testing.T) {
 	}
 }
 
-func TestForceFullSyncConsumeIsNonClearing(t *testing.T) {
-	resetForceFullSyncForTest()
-	defer resetForceFullSyncForTest()
-
-	if !consumePendingForceFullSync() {
-		t.Fatal("expected first consume to return true at process start")
-	}
-	if !consumePendingForceFullSync() {
-		t.Fatal("consume should not clear — repeated calls return true until clearPendingForceFullSync()")
-	}
-
-	clearPendingForceFullSync()
-
-	if consumePendingForceFullSync() {
-		t.Fatal("after clearPendingForceFullSync, consume must return false")
-	}
-}
-
-// resetForceFullSyncForTest restores the package-level flag so tests are
-// independent regardless of execution order.
-func resetForceFullSyncForTest() {
-	forceFullSyncMu.Lock()
-	defer forceFullSyncMu.Unlock()
-	pendingForceFullSync = true
-}

--- a/dev/nginx2/site-available-only.conf
+++ b/dev/nginx2/site-available-only.conf
@@ -6,6 +6,7 @@ server {
     ssl_certificate_key /etc/nginx/ssl/certkit.key;
 
     location / {
+        add_header Content-Type text/plain;
         return 200 "nginx2 available-only\n";
     }
 }

--- a/dev/nginx2/site-both.conf
+++ b/dev/nginx2/site-both.conf
@@ -6,6 +6,7 @@ server {
     ssl_certificate_key /etc/nginx/ssl/certkit.key;
 
     location / {
+        add_header Content-Type text/plain;
         return 200 "nginx2 both\n";
     }
 }

--- a/dev/nginx2/site-enabled-only.conf
+++ b/dev/nginx2/site-enabled-only.conf
@@ -6,6 +6,7 @@ server {
     ssl_certificate_key /etc/nginx/ssl/certkit.key;
 
     location / {
+        add_header Content-Type text/plain;
         return 200 "nginx2 enabled-only\n";
     }
 }

--- a/dev/systemd/nginx-certkit.conf
+++ b/dev/systemd/nginx-certkit.conf
@@ -6,6 +6,7 @@ server {
   ssl_certificate_key /etc/nginx/ssl/certkit.key;
 
   location / {
-    return 200 "ok";
+    add_header Content-Type text/plain;
+    return 200 "This is nginx running on a docker container with systemd";
   }
 }

--- a/utils/cert.go
+++ b/utils/cert.go
@@ -32,25 +32,26 @@ func GetCertificateSha1(path string) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func GetCertificateSha1FromPfx(path string, password string) (string, error) {
+func DoesPfxContainSha1(path string, password string, expectedSha1 string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 
-	return GetCertificateSha1FromPfxBytes(data, password)
+	return DoesPfxBytesContainSha1(data, password, expectedSha1)
 }
 
-func GetCertificateSha1FromPfxBytes(data []byte, password string) (string, error) {
+func DoesPfxBytesContainSha1(data []byte, password string, expectedSha1 string) (bool, error) {
 	if len(data) == 0 {
-		return "", fmt.Errorf("empty PFX payload")
+		return false, fmt.Errorf("empty PFX payload")
 	}
 
 	pemBlocks, err := pkcs12.ToPEM(data, password)
 	if err != nil {
-		return "", fmt.Errorf("decode pfx: %w", err)
+		return false, fmt.Errorf("decode pfx: %w", err)
 	}
 
+	pfxContainsAtLeastOneCertificateBlock := false
 	for _, block := range pemBlocks {
 		if block == nil || block.Type != "CERTIFICATE" {
 			continue
@@ -58,13 +59,19 @@ func GetCertificateSha1FromPfxBytes(data []byte, password string) (string, error
 
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return "", fmt.Errorf("parse certificate from pfx: %w", err)
+			return false, fmt.Errorf("parse certificate from pfx: %w", err)
 		}
+		pfxContainsAtLeastOneCertificateBlock = true
 		sum := sha1.Sum(cert.Raw)
-		return hex.EncodeToString(sum[:]), nil
+		if strings.EqualFold(hex.EncodeToString(sum[:]), expectedSha1) {
+			return true, nil
+		}
 	}
 
-	return "", fmt.Errorf("no certificate block found in PFX")
+	if !pfxContainsAtLeastOneCertificateBlock {
+		return false, fmt.Errorf("no certificate block found in PFX")
+	}
+	return false, nil
 }
 
 func firstCertificateDERFromPEM(data []byte) ([]byte, error) {

--- a/utils/powershell_e2e_test.go
+++ b/utils/powershell_e2e_test.go
@@ -1,0 +1,297 @@
+//go:build windows
+
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// End-to-end tests that build a script the way runUpdateCommand does and run
+// it through powershell.exe to confirm the wrapper genuinely propagates
+// errors and supports realistic multi-line user commands.
+
+type scriptScenario struct {
+	name       string
+	userCmd    string
+	vars       []UpdateVariable
+	sysInject  string
+	wantErr    bool     // true if RunPowerShellViaStdin must return a non-nil error
+	wantOut    []string // substrings that MUST appear in combined output
+	wantNotOut []string // substrings that must NOT appear
+}
+
+func runScenario(t *testing.T, s scriptScenario) {
+	t.Helper()
+	script, _ := BuildPowerShellScript(s.userCmd, s.vars, s.sysInject)
+	out, err := RunPowerShellViaStdin(script)
+	if s.wantErr && err == nil {
+		t.Fatalf("expected error, got success.\nout=%s", out)
+	}
+	if !s.wantErr && err != nil {
+		t.Fatalf("expected success, got error=%v\nout=%s", err, out)
+	}
+	for _, want := range s.wantOut {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\nout=%s", want, out)
+		}
+	}
+	for _, notWant := range s.wantNotOut {
+		if strings.Contains(out, notWant) {
+			t.Errorf("expected output NOT to contain %q\nout=%s", notWant, out)
+		}
+	}
+}
+
+// --- Success paths -----------------------------------------------------------
+
+func TestE2E_MultilineIfElse(t *testing.T) {
+	runScenario(t, scriptScenario{
+		name: "if/else block spanning lines",
+		userCmd: `$x = 5
+if ($x -gt 3) {
+    Write-Host "big"
+} else {
+    Write-Host "small"
+}`,
+		wantOut:    []string{"big"},
+		wantNotOut: []string{"small"},
+	})
+}
+
+func TestE2E_MultilineForeach(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `foreach ($i in 1..3) {
+    Write-Host "iter-$i"
+}`,
+		wantOut: []string{"iter-1", "iter-2", "iter-3"},
+	})
+}
+
+func TestE2E_FunctionDefinitionAndCall(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `function Greet($who) {
+    Write-Host "hello $who"
+}
+Greet "world"
+Greet "again"`,
+		wantOut: []string{"hello world", "hello again"},
+	})
+}
+
+func TestE2E_HereStringMultiline(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `$msg = @"
+line one
+line two
+line three
+"@
+Write-Host $msg`,
+		wantOut: []string{"line one", "line two", "line three"},
+	})
+}
+
+func TestE2E_PipelineSuccess(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `1..3 |
+  ForEach-Object { "n=$_" } |
+  Sort-Object`,
+		wantOut: []string{"n=1", "n=2", "n=3"},
+	})
+}
+
+func TestE2E_TryCatchInsideUserScript(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `try {
+    Get-Item "C:\does-not-exist-xyz"
+} catch {
+    Write-Host "user-handled: $($_.Exception.Message)"
+}
+Write-Host "after-catch"`,
+		wantOut: []string{"user-handled:", "after-catch"},
+	})
+}
+
+// --- Variable injection ------------------------------------------------------
+
+func TestE2E_VariableUsedInsideMultilineBlock(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `if ($PW.Length -gt 0) {
+    Write-Host "len=$($PW.Length)"
+    Write-Host "val=$PW"
+}`,
+		vars:    []UpdateVariable{{Name: "PW", Value: "secret123"}},
+		wantOut: []string{"len=9", "val=secret123"},
+	})
+}
+
+func TestE2E_VariableWithSingleQuote(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "got=$PW"`,
+		vars:    []UpdateVariable{{Name: "PW", Value: "it's a secret"}},
+		wantOut: []string{"got=it's a secret"},
+	})
+}
+
+func TestE2E_SystemInjectedVarsAccessible(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd:   `Write-Host "thumb=$thumbprint cert=$certInfo"`,
+		sysInject: "$thumbprint = 'ABCDEF'\n$certInfo = 'fake-cert'\n",
+		wantOut:   []string{"thumb=ABCDEF cert=fake-cert"},
+	})
+}
+
+// --- Error propagation -------------------------------------------------------
+
+func TestE2E_CmdletErrorEarlyHalts(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Get-Item "C:\does-not-exist-xyz-abc"
+Write-Host "should-not-reach"`,
+		wantErr:    true,
+		wantNotOut: []string{"should-not-reach"},
+	})
+}
+
+func TestE2E_CmdletErrorMidMultilineHalts(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "before"
+foreach ($i in 1..5) {
+    if ($i -eq 3) {
+        Get-Item "C:\does-not-exist-xyz"
+    }
+    Write-Host "iter-$i"
+}
+Write-Host "after-loop"`,
+		wantErr:    true,
+		wantOut:    []string{"before", "iter-1", "iter-2"},
+		wantNotOut: []string{"iter-3", "iter-4", "iter-5", "after-loop"},
+	})
+}
+
+func TestE2E_ThrowFromUserScriptPropagates(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "starting"
+throw "user-says-no"
+Write-Host "should-not-reach"`,
+		wantErr:    true,
+		wantOut:    []string{"starting", "user-says-no"},
+		wantNotOut: []string{"should-not-reach"},
+	})
+}
+
+func TestE2E_NonTerminatingErrorBecomesTerminating(t *testing.T) {
+	// Without $ErrorActionPreference='Stop', Get-ChildItem on a missing path
+	// would only emit a non-terminating error and execution would continue.
+	// The preamble in BuildPowerShellScript flips it to terminating.
+	runScenario(t, scriptScenario{
+		userCmd: `Get-ChildItem "C:\does-not-exist-xyz"
+Write-Host "should-not-reach"`,
+		wantErr:    true,
+		wantNotOut: []string{"should-not-reach"},
+	})
+}
+
+func TestE2E_NativeCommandFailureAtEnd(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "before"
+cmd /c "exit 13"`,
+		wantErr: true,
+		wantOut: []string{"before", "Command exited with code 13"},
+	})
+}
+
+// Native commands don't auto-halt mid-script — but a user who explicitly
+// checks $LASTEXITCODE can throw to abort. Confirm that pattern works.
+func TestE2E_NativeCommandFailureMidScriptWithCheck(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "before"
+cmd /c "exit 4"
+if ($LASTEXITCODE -ne 0) { throw "native step failed: $LASTEXITCODE" }
+Write-Host "should-not-reach"`,
+		wantErr:    true,
+		wantOut:    []string{"before", "native step failed: 4"},
+		wantNotOut: []string{"should-not-reach"},
+	})
+}
+
+// Without an explicit $LASTEXITCODE check, a mid-script native failure does
+// NOT halt — execution continues until the trailing check at the end. This
+// test documents that behavior so future changes don't regress it silently.
+func TestE2E_NativeCommandFailureMidScriptWithoutCheck(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "before"
+cmd /c "exit 5"
+Write-Host "still-running"
+cmd /c "exit 0"`, // resets $LASTEXITCODE; trailing check sees 0 → success
+		wantErr: false,
+		wantOut: []string{"before", "still-running"},
+	})
+}
+
+// --- Edge cases --------------------------------------------------------------
+
+func TestE2E_MultilineWithComments(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `# leading comment
+Write-Host "one"
+# mid comment
+Write-Host "two" # trailing
+<#
+   block
+   comment
+#>
+Write-Host "three"`,
+		wantOut: []string{"one", "two", "three"},
+	})
+}
+
+func TestE2E_StdoutAndStderrBothCaptured(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "stdout-line"
+[Console]::Error.WriteLine("stderr-line")`,
+		wantOut: []string{"stdout-line", "stderr-line"},
+	})
+}
+
+func TestE2E_OutputOrderingPreserved(t *testing.T) {
+	runScenario(t, scriptScenario{
+		userCmd: `Write-Host "A"
+Write-Host "B"
+Write-Host "C"`,
+		wantOut: []string{"A", "B", "C"},
+	})
+	// Also assert ordering explicitly.
+	script, _ := BuildPowerShellScript("Write-Host A\nWrite-Host B\nWrite-Host C", nil, "")
+	out, err := RunPowerShellViaStdin(script)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a, b, c := strings.Index(out, "A"), strings.Index(out, "B"), strings.Index(out, "C")
+	if !(a >= 0 && a < b && b < c) {
+		t.Fatalf("expected A,B,C in order. out=%s", out)
+	}
+}
+
+func TestE2E_EmptyUserCmd(t *testing.T) {
+	// runUpdateCommand short-circuits empty input upstream, but the builder
+	// itself should still produce a runnable script if called with "".
+	runScenario(t, scriptScenario{
+		userCmd: "",
+		wantErr: false,
+	})
+}
+
+func TestE2E_ScriptUsesVariableThenSystemInjectedVar(t *testing.T) {
+	// Realistic windows-cert-store flow: user references both their own
+	// variable and the system-injected $thumbprint inside a multi-line block.
+	runScenario(t, scriptScenario{
+		userCmd: `if ($thumbprint -and $TARGET_SERVICE) {
+    Write-Host "binding $thumbprint to $TARGET_SERVICE"
+} else {
+    throw "missing values"
+}`,
+		vars:      []UpdateVariable{{Name: "TARGET_SERVICE", Value: "MyApp"}},
+		sysInject: "$thumbprint = 'ABC123'\n",
+		wantOut:   []string{"binding ABC123 to MyApp"},
+	})
+}

--- a/utils/powershell_windows.go
+++ b/utils/powershell_windows.go
@@ -75,3 +75,48 @@ func RunPowerShellViaStdin(scriptContent string) (string, error) {
 	}
 	return output, nil
 }
+
+// BuildPowerShellScript composes a script for piping to RunPowerShellViaStdin:
+//  1. $ErrorActionPreference = 'Stop' fail-fast preamble.
+//  2. One $NAME = 'VALUE' line per validated user variable. Variables whose
+//     names don't match [A-Za-z_][A-Za-z0-9_]* are silently skipped — defense
+//     in depth against shell injection via the assignment line.
+//  3. Optional system-injected lines (e.g. the windows-cert-store cert load
+//     block exposing $thumbprint and $certificate). Pass "" if not needed.
+//  4. The user's command verbatim, with a trailing newline if missing.
+//
+// Returns the full script and the count of variables actually injected. The
+// caller can compare this to len(vars) to detect dropped invalid names.
+func BuildPowerShellScript(userCmd string, vars []UpdateVariable, systemInjected string) (string, int) {
+	var b strings.Builder
+	b.WriteString("$ErrorActionPreference = 'Stop'\n")
+
+	appliedVarCount := 0
+	for _, v := range vars {
+		if !IsValidVariableName(v.Name) {
+			continue
+		}
+		fmt.Fprintf(&b, "$%s = '%s'\n", v.Name, escapePowerShellSingleQuoted(v.Value))
+		appliedVarCount++
+	}
+
+	if systemInjected != "" {
+		b.WriteString(systemInjected)
+		if !strings.HasSuffix(systemInjected, "\n") {
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString(userCmd)
+	if !strings.HasSuffix(userCmd, "\n") {
+		b.WriteString("\n")
+	}
+
+	return b.String(), appliedVarCount
+}
+
+// escapePowerShellSingleQuoted escapes a value for inclusion inside a
+// single-quoted PowerShell string by doubling each ' to ''.
+func escapePowerShellSingleQuoted(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}

--- a/utils/powershell_windows.go
+++ b/utils/powershell_windows.go
@@ -87,14 +87,7 @@ func RunPowerShellViaStdin(scriptContent string) (string, error) {
 	cmd.Stdin = strings.NewReader(encodedScript)
 
 	out, err := cmd.CombinedOutput()
-	output := strings.TrimSpace(string(out))
-	if err != nil {
-		if output != "" {
-			return output, fmt.Errorf("%w: %s", err, output)
-		}
-		return "", err
-	}
-	return output, nil
+	return strings.TrimSpace(string(out)), err
 }
 
 // BuildPowerShellScript composes the inner script body that

--- a/utils/powershell_windows.go
+++ b/utils/powershell_windows.go
@@ -47,3 +47,31 @@ func RunPowerShell(input string) (string, error) {
 	}
 	return output, nil
 }
+
+// RunPowerShellViaStdin executes the given script content by piping it to
+// powershell.exe via stdin. Use this when the script contains user-supplied
+// templates plus secret variable assignments — stdin keeps secrets off the
+// command line where Win32_Process would expose them to other processes.
+//
+// Other call sites that build inline scripts from trusted, escaped values
+// should keep using RunPowerShell.
+func RunPowerShellViaStdin(scriptContent string) (string, error) {
+	cmd := exec.Command(
+		"powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-ExecutionPolicy", "Bypass",
+		"-Command", "-",
+	)
+	cmd.Stdin = strings.NewReader(scriptContent)
+
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		if output != "" {
+			return output, fmt.Errorf("%w: %s", err, output)
+		}
+		return "", err
+	}
+	return output, nil
+}

--- a/utils/powershell_windows.go
+++ b/utils/powershell_windows.go
@@ -52,37 +52,39 @@ func RunPowerShell(input string) (string, error) {
 // RunPowerShellViaStdin executes the given script content via powershell.exe,
 // keeping the script (and any embedded secrets) off the command line.
 //
+// The script content is base64-encoded and piped to stdin. A short, fixed
+// bootstrapper passed via -Command reads stdin, decodes it, and invokes the
+// result as a script block inside a try/catch. The bootstrapper itself
+// contains no user data, so what shows up in Win32_Process.CommandLine is
+// only the literal bootstrapper text — secrets stay on stdin.
+//
 // Why the base64 dance? `powershell.exe -Command -` reads stdin one logical
 // statement at a time at the prompt level, so multi-line constructs like
-// `try { ... } catch { ... }`, `& { ... }`, and even setting
-// `$ErrorActionPreference = 'Stop'` followed by another command don't carry
-// over reliably — a `trap` on line 1 doesn't fire for an error on line 4,
-// and unhandled terminating errors silently exit 0.
+// `try { ... } catch { ... }` and `& { ... }` don't carry over reliably —
+// terminating errors silently exit 0. Routing the user script through
+// [scriptblock]::Create() runs it under normal script semantics where
+// terminating errors propagate up to the bootstrapper's catch.
 //
-// To get reliable error propagation while still using stdin (so secrets
-// don't end up on the powershell.exe command line where Win32_Process would
-// expose them), we send a single physical line to stdin: a try/catch
-// wrapper that decodes the base64-encoded script and invokes it as a script
-// block. Inside the script block, normal multi-line semantics apply, so
-// terminating errors bubble up to the outer catch and produce exit 1.
+// On error the catch block writes the formatted ErrorRecord directly to
+// .NET's Console.Error stream rather than calling Write-Error, which would
+// otherwise be wrapped in CLIXML when stderr is redirected to a pipe.
 //
 // Other call sites that build inline scripts from trusted, escaped values
 // should keep using RunPowerShell.
 func RunPowerShellViaStdin(scriptContent string) (string, error) {
-	encoded := base64.StdEncoding.EncodeToString([]byte(scriptContent))
-	wrapper := fmt.Sprintf(
-		`try { & ([scriptblock]::Create([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('%s')))); exit 0 } catch { Write-Error -ErrorRecord $_; exit 1 }`+"\n",
-		encoded,
-	)
+	encodedScript := base64.StdEncoding.EncodeToString([]byte(scriptContent))
+
+	// Fixed bootstrapper — no user data interpolated here. Edit with care.
+	bootstrap := `try { $encoded = [Console]::In.ReadToEnd(); $script = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($encoded)); & ([scriptblock]::Create($script)); exit 0 } catch { [Console]::Error.WriteLine(($_ | Out-String)); exit 1 }`
 
 	cmd := exec.Command(
 		"powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
 		"-ExecutionPolicy", "Bypass",
-		"-Command", "-",
+		"-Command", bootstrap,
 	)
-	cmd.Stdin = strings.NewReader(wrapper)
+	cmd.Stdin = strings.NewReader(encodedScript)
 
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))

--- a/utils/powershell_windows.go
+++ b/utils/powershell_windows.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,14 +49,32 @@ func RunPowerShell(input string) (string, error) {
 	return output, nil
 }
 
-// RunPowerShellViaStdin executes the given script content by piping it to
-// powershell.exe via stdin. Use this when the script contains user-supplied
-// templates plus secret variable assignments — stdin keeps secrets off the
-// command line where Win32_Process would expose them to other processes.
+// RunPowerShellViaStdin executes the given script content via powershell.exe,
+// keeping the script (and any embedded secrets) off the command line.
+//
+// Why the base64 dance? `powershell.exe -Command -` reads stdin one logical
+// statement at a time at the prompt level, so multi-line constructs like
+// `try { ... } catch { ... }`, `& { ... }`, and even setting
+// `$ErrorActionPreference = 'Stop'` followed by another command don't carry
+// over reliably — a `trap` on line 1 doesn't fire for an error on line 4,
+// and unhandled terminating errors silently exit 0.
+//
+// To get reliable error propagation while still using stdin (so secrets
+// don't end up on the powershell.exe command line where Win32_Process would
+// expose them), we send a single physical line to stdin: a try/catch
+// wrapper that decodes the base64-encoded script and invokes it as a script
+// block. Inside the script block, normal multi-line semantics apply, so
+// terminating errors bubble up to the outer catch and produce exit 1.
 //
 // Other call sites that build inline scripts from trusted, escaped values
 // should keep using RunPowerShell.
 func RunPowerShellViaStdin(scriptContent string) (string, error) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(scriptContent))
+	wrapper := fmt.Sprintf(
+		`try { & ([scriptblock]::Create([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('%s')))); exit 0 } catch { Write-Error -ErrorRecord $_; exit 1 }`+"\n",
+		encoded,
+	)
+
 	cmd := exec.Command(
 		"powershell.exe",
 		"-NoProfile",
@@ -63,7 +82,7 @@ func RunPowerShellViaStdin(scriptContent string) (string, error) {
 		"-ExecutionPolicy", "Bypass",
 		"-Command", "-",
 	)
-	cmd.Stdin = strings.NewReader(scriptContent)
+	cmd.Stdin = strings.NewReader(wrapper)
 
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
@@ -76,14 +95,21 @@ func RunPowerShellViaStdin(scriptContent string) (string, error) {
 	return output, nil
 }
 
-// BuildPowerShellScript composes a script for piping to RunPowerShellViaStdin:
-//  1. $ErrorActionPreference = 'Stop' fail-fast preamble.
+// BuildPowerShellScript composes the inner script body that
+// RunPowerShellScript will wrap in its try/catch. Layout:
+//  1. $ErrorActionPreference = 'Stop' so cmdlet errors are terminating.
 //  2. One $NAME = 'VALUE' line per validated user variable. Variables whose
 //     names don't match [A-Za-z_][A-Za-z0-9_]* are silently skipped — defense
 //     in depth against shell injection via the assignment line.
 //  3. Optional system-injected lines (e.g. the windows-cert-store cert load
 //     block exposing $thumbprint and $certificate). Pass "" if not needed.
 //  4. The user's command verbatim, with a trailing newline if missing.
+//  5. A trailing $LASTEXITCODE check that throws if a native command exited
+//     non-zero — $ErrorActionPreference doesn't apply to native exes, so we
+//     have to convert their failure into a terminating error explicitly.
+//
+// Terminating errors propagate up to RunPowerShellScript's outer try/catch
+// and produce exit 1.
 //
 // Returns the full script and the count of variables actually injected. The
 // caller can compare this to len(vars) to detect dropped invalid names.
@@ -112,11 +138,13 @@ func BuildPowerShellScript(userCmd string, vars []UpdateVariable, systemInjected
 		b.WriteString("\n")
 	}
 
+	b.WriteString("if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) { throw (\"Command exited with code \" + $LASTEXITCODE) }\n")
+
 	return b.String(), appliedVarCount
 }
 
 // escapePowerShellSingleQuoted escapes a value for inclusion inside a
-// single-quoted PowerShell string by doubling each ' to ''.
+// single-quoted PowerShell string by doubling each ' to ”.
 func escapePowerShellSingleQuoted(value string) string {
 	return strings.ReplaceAll(value, "'", "''")
 }

--- a/utils/powershell_windows_test.go
+++ b/utils/powershell_windows_test.go
@@ -1,16 +1,14 @@
 //go:build windows
 
-package agent
+package utils
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/certkit-io/certkit-agent/api"
 )
 
-func TestBuildPowerShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
-	script, count := buildPowerShellScript("Write-Host hi", nil, "cfg-a")
+func TestBuildPowerShellScript_NoVarsNoExtras(t *testing.T) {
+	script, count := BuildPowerShellScript("Write-Host hi", nil, "")
 
 	if count != 0 {
 		t.Fatalf("expected 0 vars applied, got %d", count)
@@ -21,12 +19,12 @@ func TestBuildPowerShellScript_NoVarsEmitsPreambleAndCommand(t *testing.T) {
 	}
 }
 
-func TestBuildPowerShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T) {
-	updateCmd := "Write-Host one\nforeach ($i in 1..3) {\n  Write-Host $i\n}"
-	script, _ := buildPowerShellScript(updateCmd, nil, "cfg-a")
+func TestBuildPowerShellScript_PreservesEmbeddedNewlinesInUserCmd(t *testing.T) {
+	userCmd := "Write-Host one\nforeach ($i in 1..3) {\n  Write-Host $i\n}"
+	script, _ := BuildPowerShellScript(userCmd, nil, "")
 
-	if !strings.Contains(script, updateCmd) {
-		t.Fatalf("multiline update_cmd was modified during script build:\n%s", script)
+	if !strings.Contains(script, userCmd) {
+		t.Fatalf("multiline user_cmd was modified during script build:\n%s", script)
 	}
 	if !strings.HasSuffix(script, "\n") {
 		t.Fatalf("script must end with newline:\n%s", script)
@@ -34,10 +32,10 @@ func TestBuildPowerShellScript_PreservesEmbeddedNewlinesInUpdateCmd(t *testing.T
 }
 
 func TestBuildPowerShellScript_EscapesSingleQuotesInValue(t *testing.T) {
-	vars := []api.UpdateVariable{
+	vars := []UpdateVariable{
 		{Name: "PW", Value: "it's a secret"},
 	}
-	script, count := buildPowerShellScript("Write-Host $PW", vars, "cfg-a")
+	script, count := BuildPowerShellScript("Write-Host $PW", vars, "")
 
 	if count != 1 {
 		t.Fatalf("expected 1 var applied, got %d", count)
@@ -50,13 +48,13 @@ func TestBuildPowerShellScript_EscapesSingleQuotesInValue(t *testing.T) {
 }
 
 func TestBuildPowerShellScript_SkipsInvalidVariableNames(t *testing.T) {
-	vars := []api.UpdateVariable{
+	vars := []UpdateVariable{
 		{Name: "GOOD", Value: "1"},
 		{Name: "BAD NAME", Value: "2"},
 		{Name: "9LEAD", Value: "3"},
 		{Name: "PW", Value: "4"},
 	}
-	script, count := buildPowerShellScript("Write-Host done", vars, "cfg-a")
+	script, count := BuildPowerShellScript("Write-Host done", vars, "")
 
 	if count != 2 {
 		t.Fatalf("expected 2 valid vars applied, got %d", count)
@@ -69,11 +67,12 @@ func TestBuildPowerShellScript_SkipsInvalidVariableNames(t *testing.T) {
 	}
 }
 
-func TestBuildWindowsCertStoreScript_OrderingAndCertLoad(t *testing.T) {
-	vars := []api.UpdateVariable{
+func TestBuildPowerShellScript_SystemInjectedSitsBetweenVarsAndUserCmd(t *testing.T) {
+	vars := []UpdateVariable{
 		{Name: "PW", Value: "secret"},
 	}
-	script, count := buildWindowsCertStoreScript("ABC123", "Write-Host $PW $thumbprint", vars)
+	systemInjected := "$thumbprint = 'ABC123'\n$certificate = Get-Item ...\n"
+	script, count := BuildPowerShellScript("Write-Host $PW $thumbprint", vars, systemInjected)
 
 	if count != 1 {
 		t.Fatalf("expected 1 var applied, got %d", count)
@@ -81,16 +80,26 @@ func TestBuildWindowsCertStoreScript_OrderingAndCertLoad(t *testing.T) {
 
 	idxPreamble := strings.Index(script, "$ErrorActionPreference = 'Stop'")
 	idxVar := strings.Index(script, "$PW = 'secret'")
-	idxCert := strings.Index(script, "$certificate = Get-Item")
+	idxThumb := strings.Index(script, "$thumbprint = 'ABC123'")
 	idxUserCmd := strings.Index(script, "Write-Host $PW $thumbprint")
 
-	if idxPreamble < 0 || idxVar < 0 || idxCert < 0 || idxUserCmd < 0 {
+	if idxPreamble < 0 || idxVar < 0 || idxThumb < 0 || idxUserCmd < 0 {
 		t.Fatalf("missing expected lines:\n%s", script)
 	}
 
-	// Order must be: preamble → vars → cert load → user cmd
-	if !(idxPreamble < idxVar && idxVar < idxCert && idxCert < idxUserCmd) {
-		t.Fatalf("script ordering wrong (preamble=%d vars=%d cert=%d user=%d):\n%s",
-			idxPreamble, idxVar, idxCert, idxUserCmd, script)
+	// Order must be: preamble → vars → system-injected → user cmd.
+	if !(idxPreamble < idxVar && idxVar < idxThumb && idxThumb < idxUserCmd) {
+		t.Fatalf("script ordering wrong (preamble=%d vars=%d thumb=%d user=%d):\n%s",
+			idxPreamble, idxVar, idxThumb, idxUserCmd, script)
+	}
+}
+
+func TestBuildPowerShellScript_SystemInjectedTrailingNewlineNotDuplicated(t *testing.T) {
+	systemInjected := "$thumbprint = 'X'\n"
+	script, _ := BuildPowerShellScript("Write-Host hi", nil, systemInjected)
+
+	// Should contain the systemInjected once, with no doubled blank line.
+	if strings.Contains(script, "\n\n") {
+		t.Fatalf("unexpected blank line in script:\n%s", script)
 	}
 }

--- a/utils/powershell_windows_test.go
+++ b/utils/powershell_windows_test.go
@@ -13,7 +13,9 @@ func TestBuildPowerShellScript_NoVarsNoExtras(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("expected 0 vars applied, got %d", count)
 	}
-	want := "$ErrorActionPreference = 'Stop'\nWrite-Host hi\n"
+	want := "$ErrorActionPreference = 'Stop'\n" +
+		"Write-Host hi\n" +
+		"if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) { throw (\"Command exited with code \" + $LASTEXITCODE) }\n"
 	if script != want {
 		t.Fatalf("script mismatch:\n got: %q\nwant: %q", script, want)
 	}

--- a/utils/variables.go
+++ b/utils/variables.go
@@ -1,0 +1,29 @@
+package utils
+
+// UpdateVariable is a name/value pair injected into update_cmd execution.
+// Values are sensitive and must never be persisted to disk or sent back to
+// the server.
+type UpdateVariable struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// IsValidVariableName matches [A-Za-z_][A-Za-z0-9_]* — defense in depth so
+// a malformed variable name from the server cannot inject shell or
+// PowerShell syntax via the assignment line.
+func IsValidVariableName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/utils/variables_test.go
+++ b/utils/variables_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import "testing"
+
+func TestIsValidVariableName(t *testing.T) {
+	good := []string{"DB", "_X", "DB_PASSWORD", "x9", "_0", "Mixed_Case_99"}
+	bad := []string{"", "9LEAD", "FOO BAR", "FOO;rm", "FOO-BAR", "FOO$", "FOO\nBAR"}
+
+	for _, name := range good {
+		if !IsValidVariableName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+	for _, name := range bad {
+		if IsValidVariableName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}


### PR DESCRIPTION
The CertKit app now supports user defined variables and much more robust remote script editing.  These are the necessary agent changes to enable things.  User defined variables are only stored in memory on the agent, never persisted to disk.  The update command is run via stdin to keep any sensitive details out of shell and other operating system logs.