### PR TITLE
Surface powershell script error messages in all cases

### DIFF
--- a/agent/synchronize_windows_cert_store_windows.go
+++ b/agent/synchronize_windows_cert_store_windows.go
@@ -21,13 +21,10 @@ func synchronizeWindowsCertStoreCertificate(cfg config.CertificateConfiguration,
 				return "", nil
 			}
 			out, err := runWindowsCertStoreUpdateCmd(cfg.Id, thumbprint, cfg.UpdateCmd, getUpdateVariables(cfg.Id))
-			if err != nil {
-				return "", err
-			}
 			if out != "" {
-				return fmt.Sprintf("Update command output: \n%s", out), nil
+				out = fmt.Sprintf("Update command output: \n%s", out)
 			}
-			return "", nil
+			return out, err
 		},
 	})
 }

--- a/agent/synchronize_windows_common.go
+++ b/agent/synchronize_windows_common.go
@@ -87,7 +87,18 @@ func synchronizeWindowsServiceCert(cfg config.CertificateConfiguration, change C
 		out, err := svc.applyFn(thumbprint)
 		if err != nil {
 			status.Status = statusErrorUpdateCmd
-			status.Message = fmt.Sprintf("Error applying %s certificate: %v", svc.serviceName, err)
+			// Surface both like synchronize.go's runUpdateCommand path:
+			// some applyFns return a bare *exec.ExitError with the actual
+			// PowerShell error text in `out` (e.g. WindowsCertStore via
+			// RunPowerShellViaStdin), while others wrap output into `err`
+			// already (IIS / RRAS / RDP via RunPowerShell) and pass an
+			// empty `out`. Including `out` only when non-empty keeps the
+			// wrapped-err callers from duplicating their output.
+			if strings.TrimSpace(out) != "" {
+				status.Message = fmt.Sprintf("Error applying %s certificate: %v\n%s", svc.serviceName, err, out)
+			} else {
+				status.Message = fmt.Sprintf("Error applying %s certificate: %v", svc.serviceName, err)
+			}
 			return status
 		}
 		if out != "" {


### PR DESCRIPTION
In some specific instances (Windows Certificate Store deployments mainly) the error message was not very helpful. This was due to the output being dropped by the synchronization function.  Include it in the status message for better debugging.