### PR TITLE
Remove some systemd hardening options 

### DIFF
--- a/install/linux.go
+++ b/install/linux.go
@@ -212,8 +212,6 @@ NoNewPrivileges=true
 ProtectControlGroups=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
-LockPersonality=true
-MemoryDenyWriteExecute=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
 


### PR DESCRIPTION
Node/V8 and PM2 have trouble with some of the default hardening options we chose for the agent.  We are removing them for compatability purposes.