### PR TITLE
GitLab Inventory Provider

### DIFF
--- a/inventory/gitlab.go
+++ b/inventory/gitlab.go
@@ -1,9 +1,10 @@
 package inventory
 
 import (
-	"errors"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -17,113 +18,104 @@ func (GitLabProvider) Name() string {
 	return "gitlab"
 }
 
+// gitlabService is a bundled GitLab service that can terminate TLS in the
+// Omnibus nginx. Each is keyed off its own external_url and
+// *_nginx['ssl_certificate*'] settings in /etc/gitlab/gitlab.rb and reported as
+// its own inventory item.
+type gitlabService struct {
+	server   string
+	nginxKey string
+	urlKey   string
+}
+
+var gitlabServices = []gitlabService{
+	{"gitlab", "nginx", "external_url"},
+	{"gitlab-registry", "registry_nginx", "registry_external_url"},
+	{"gitlab-mattermost", "mattermost_nginx", "mattermost_external_url"},
+	{"gitlab-pages", "pages_nginx", "pages_external_url"},
+}
+
 func (GitLabProvider) Collect() ([]api.InventoryItem, error) {
-	configFiles, err := expandConfigGlobs([]string{
-		"/etc/gitlab/gitlab.rb",
-	})
+	configFiles, err := expandConfigGlobs([]string{"/etc/gitlab/gitlab.rb"})
 	if err != nil {
 		return nil, err
 	}
 
 	items := make([]api.InventoryItem, 0)
 	for _, path := range configFiles {
-		certs, keys, domains, err := parseGitLabConfig(path)
+		data, err := utils.ReadFileBytes(path)
 		if err != nil {
-			log.Printf("Inventory parse error for %s: %v", path, err)
+			log.Printf("Inventory read error for %s: %v", path, err)
 			continue
 		}
-
-		pairs := len(certs)
-		if len(keys) < pairs {
-			pairs = len(keys)
-		}
-		for i := 0; i < pairs; i++ {
-			items = append(items, api.InventoryItem{
-				Server:          "gitlab",
-				ConfigPath:      path,
-				CertificatePath: certs[i],
-				KeyPath:         keys[i],
-				Domains:         joinDomains(domains),
-			})
-		}
+		items = append(items, parseGitLabConfig(data, path, nodeFQDN())...)
 	}
 
 	return items, nil
 }
 
-func parseGitLabConfig(path string) ([]string, []string, []string, error) {
-	data, err := utils.ReadFileBytes(path)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+func parseGitLabConfig(data []byte, path, fqdn string) []api.InventoryItem {
+	// GitLab interpolates #{node['fqdn']} (the machine FQDN, hostname -f) into its
+	// default cert paths, so resolve it for the whole file up front.
+	lines := strings.Split(strings.ReplaceAll(string(data), "#{node['fqdn']}", fqdn), "\n")
 
-	// Example: nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"
-	//      Or: nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"
-	reCert := regexp.MustCompile(`(?i)^\s*nginx\[['"]ssl_certificate['"]\] = ['"](.*?)['"]`)
+	// GitLab auto-renews its default cert via Let's Encrypt unless explicitly
+	// disabled; skip those so certkit doesn't fight `gitlab-ctl renew-le-certs`.
+	leDisabled := strings.EqualFold(gitlabValue(lines, `letsencrypt\[['"]enable['"]\]\s*=\s*(true|false)`), "false")
 
-	// Example: nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"
-	//      Or: nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"
-	reKey := regexp.MustCompile(`(?i)^\s*nginx\[['"]ssl_certificate_key['"]\] = ['"](.*?)['"]`)
-	
-	// Example: external_url 'https://gitlab.example.com'
-	reServer := regexp.MustCompile(`(?i)^\s*external_url\s+['"]https:\/\/(.*?)['"]`)
-
-	var certs []string
-	var keys []string
-	var domains []string
-
-	// Get the domain first, because it may be needed in the cert and key path
-	// The `external_url` line SHOULD come first, so in theory the double-loop isn't needed,
-	// but who knows maybe some user is going to copy/paste the `nginx['ssl_certificate']`
-	// and `nginx['ssl_certificate_key']` lines to the top of the file for some reason
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		if line == "" {
-			continue
+	items := make([]api.InventoryItem, 0)
+	for _, svc := range gitlabServices {
+		domain, ok := normalizeDomain(gitlabValue(lines, regexp.QuoteMeta(svc.urlKey)+`\s+['"]https://(.*?)['"]`))
+		if !ok {
+			continue // service has no https external_url
 		}
-		if match := reServer.FindStringSubmatch(line); len(match) == 2 {
-			if domain, ok := normalizeDomain(match[1]); ok {
-				domains = append(domains, domain)
-				break
+
+		cert := gitlabValue(lines, regexp.QuoteMeta(svc.nginxKey)+`\[['"]ssl_certificate['"]\]\s*=\s*['"](.*?)['"]`)
+		key := gitlabValue(lines, regexp.QuoteMeta(svc.nginxKey)+`\[['"]ssl_certificate_key['"]\]\s*=\s*['"](.*?)['"]`)
+
+		if cert == "" {
+			if !leDisabled {
+				continue // GitLab-managed via Let's Encrypt
 			}
+			// No explicit cert: GitLab serves a self-signed at its default path.
+			cert = fmt.Sprintf("/etc/gitlab/ssl/%s.crt", fqdn)
 		}
+		if key == "" {
+			key = fmt.Sprintf("/etc/gitlab/ssl/%s.key", fqdn)
+		}
+
+		items = append(items, api.InventoryItem{
+			Server:          svc.server,
+			ConfigPath:      path,
+			CertificatePath: cert,
+			KeyPath:         key,
+			Domains:         domain,
+		})
 	}
 
-	// Bail if we didn't find a domain
-	if len(domains) == 0 {
-		return certs, keys, domains, errors.New("Could not find/parse 'external_url' value")
-	}
+	return items
+}
 
-	// Now get the certs and keys
+// gitlabValue returns the first capture group of pattern across lines, anchored
+// at the start of a line and case-insensitive, or "" if nothing matches.
+func gitlabValue(lines []string, pattern string) string {
+	re := regexp.MustCompile(`(?i)^\s*` + pattern)
 	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-
-		// Default nginx['ssl_certificate'] and nginx['ssl_certificate_key'] lines
-		// use a variable for the domain name as part of the filename, so we do a
-		// string replacement to ensure we don't return the variable placeholder
-		line := strings.ReplaceAll(line, "#{node['fqdn']}", domains[0])
-
-		if match := reCert.FindStringSubmatch(line); len(match) == 2 {
-			certs = append(certs, cleanConfigValue(match[1]))
-			continue
-		}
-		if match := reKey.FindStringSubmatch(line); len(match) == 2 {
-			keys = append(keys, cleanConfigValue(match[1]))
-			continue
+		if m := re.FindStringSubmatch(line); len(m) == 2 {
+			return m[1]
 		}
 	}
+	return ""
+}
 
-	// Default behaviour is for GitLab to use /etc/gitlab/ssl/<domain>.crt
-	// and /etc/gitlab/ssl/<domain>.key, so if we didn't parse any certs or
-	// keys above then we'll assume that's what the filenames should be
-	if len(certs) == 0 {
-		certs = append(certs, fmt.Sprintf("/etc/gitlab/ssl/%s.crt", domains[0]))
+// nodeFQDN resolves the machine FQDN the way GitLab/Chef does (node['fqdn']),
+// falling back to the kernel hostname.
+func nodeFQDN() string {
+	if out, err := exec.Command("hostname", "-f").Output(); err == nil {
+		if fqdn := strings.TrimSpace(string(out)); fqdn != "" {
+			return fqdn
+		}
 	}
-	if len(keys) == 0 {
-		keys = append(keys, fmt.Sprintf("/etc/gitlab/ssl/%s.key", domains[0]))
-	}
-
-	return certs, keys, domains, nil
+	host, _ := os.Hostname()
+	return host
 }

--- a/inventory/gitlab.go
+++ b/inventory/gitlab.go
@@ -1,0 +1,129 @@
+package inventory
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/utils"
+)
+
+type GitLabProvider struct{}
+
+func (GitLabProvider) Name() string {
+	return "gitlab"
+}
+
+func (GitLabProvider) Collect() ([]api.InventoryItem, error) {
+	configFiles, err := expandConfigGlobs([]string{
+		"/etc/gitlab/gitlab.rb",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]api.InventoryItem, 0)
+	for _, path := range configFiles {
+		certs, keys, domains, err := parseGitLabConfig(path)
+		if err != nil {
+			log.Printf("Inventory parse error for %s: %v", path, err)
+			continue
+		}
+
+		pairs := len(certs)
+		if len(keys) < pairs {
+			pairs = len(keys)
+		}
+		for i := 0; i < pairs; i++ {
+			items = append(items, api.InventoryItem{
+				Server:          "gitlab",
+				ConfigPath:      path,
+				CertificatePath: certs[i],
+				KeyPath:         keys[i],
+				Domains:         joinDomains(domains),
+			})
+		}
+	}
+
+	return items, nil
+}
+
+func parseGitLabConfig(path string) ([]string, []string, []string, error) {
+	data, err := utils.ReadFileBytes(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Example: nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"
+	//      Or: nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"
+	reCert := regexp.MustCompile(`(?i)^\s*nginx\[['"]ssl_certificate['"]\] = ['"](.*?)['"]`)
+
+	// Example: nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"
+	//      Or: nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"
+	reKey := regexp.MustCompile(`(?i)^\s*nginx\[['"]ssl_certificate_key['"]\] = ['"](.*?)['"]`)
+	
+	// Example: external_url 'https://gitlab.example.com'
+	reServer := regexp.MustCompile(`(?i)^\s*external_url\s+['"]https:\/\/(.*?)['"]`)
+
+	var certs []string
+	var keys []string
+	var domains []string
+
+	// Get the domain first, because it may be needed in the cert and key path
+	// The `external_url` line SHOULD come first, so in theory the double-loop isn't needed,
+	// but who knows maybe some user is going to copy/paste the `nginx['ssl_certificate']`
+	// and `nginx['ssl_certificate_key']` lines to the top of the file for some reason
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if match := reServer.FindStringSubmatch(line); len(match) == 2 {
+			if domain, ok := normalizeDomain(match[1]); ok {
+				domains = append(domains, domain)
+				break
+			}
+		}
+	}
+
+	// Bail if we didn't find a domain
+	if len(domains) == 0 {
+		return certs, keys, domains, errors.New("Could not find/parse 'external_url' value")
+	}
+
+	// Now get the certs and keys
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		// Default nginx['ssl_certificate'] and nginx['ssl_certificate_key'] lines
+		// use a variable for the domain name as part of the filename, so we do a
+		// string replacement to ensure we don't return the variable placeholder
+		line := strings.ReplaceAll(line, "#{node['fqdn']}", domains[0])
+
+		if match := reCert.FindStringSubmatch(line); len(match) == 2 {
+			certs = append(certs, cleanConfigValue(match[1]))
+			continue
+		}
+		if match := reKey.FindStringSubmatch(line); len(match) == 2 {
+			keys = append(keys, cleanConfigValue(match[1]))
+			continue
+		}
+	}
+
+	// Default behaviour is for GitLab to use /etc/gitlab/ssl/<domain>.crt
+	// and /etc/gitlab/ssl/<domain>.key, so if we didn't parse any certs or
+	// keys above then we'll assume that's what the filenames should be
+	if len(certs) == 0 {
+		certs = append(certs, fmt.Sprintf("/etc/gitlab/ssl/%s.crt", domains[0]))
+	}
+	if len(keys) == 0 {
+		keys = append(keys, fmt.Sprintf("/etc/gitlab/ssl/%s.key", domains[0]))
+	}
+
+	return certs, keys, domains, nil
+}

--- a/inventory/gitlab.go
+++ b/inventory/gitlab.go
@@ -31,37 +31,38 @@ type gitlabService struct {
 var gitlabServices = []gitlabService{
 	{"gitlab", "nginx", "external_url"},
 	{"gitlab-registry", "registry_nginx", "registry_external_url"},
-	{"gitlab-mattermost", "mattermost_nginx", "mattermost_external_url"},
 	{"gitlab-pages", "pages_nginx", "pages_external_url"},
 }
 
+const gitlabConfigFile = "/etc/gitlab/gitlab.rb"
+
 func (GitLabProvider) Collect() ([]api.InventoryItem, error) {
-	configFiles, err := expandConfigGlobs([]string{"/etc/gitlab/gitlab.rb"})
+	// Read only gitlab.rb. Anything wrong here (file absent, unreadable, or
+	// malformed) yields no items rather than failing the whole inventory run.
+	data, err := utils.ReadFileBytes(gitlabConfigFile)
 	if err != nil {
-		return nil, err
-	}
-
-	items := make([]api.InventoryItem, 0)
-	for _, path := range configFiles {
-		data, err := utils.ReadFileBytes(path)
-		if err != nil {
-			log.Printf("Inventory read error for %s: %v", path, err)
-			continue
+		if !os.IsNotExist(err) {
+			log.Printf("Inventory read error for %s: %v", gitlabConfigFile, err)
 		}
-		items = append(items, parseGitLabConfig(data, path, nodeFQDN())...)
+		return nil, nil
 	}
 
-	return items, nil
+	return parseGitLabConfig(data, gitlabConfigFile, nodeFQDN()), nil
 }
 
 func parseGitLabConfig(data []byte, path, fqdn string) []api.InventoryItem {
-	// GitLab interpolates #{node['fqdn']} (the machine FQDN, hostname -f) into its
-	// default cert paths, so resolve it for the whole file up front.
+	// GitLab/Chef interpolates #{node['fqdn']} as the machine FQDN
+	// (hostname -f), including inside explicit certificate paths.
 	lines := strings.Split(strings.ReplaceAll(string(data), "#{node['fqdn']}", fqdn), "\n")
 
-	// GitLab auto-renews its default cert via Let's Encrypt unless explicitly
-	// disabled; skip those so certkit doesn't fight `gitlab-ctl renew-le-certs`.
-	leDisabled := strings.EqualFold(gitlabValue(lines, `letsencrypt\[['"]enable['"]\]\s*=\s*(true|false)`), "false")
+	// `false` is the only value that guarantees Let's Encrypt is off. true, unset,
+	// and commented-out all mean GitLab may be auto-issuing/renewing the certs, so
+	// in those cases we skip GitLab entirely rather than fight
+	// `gitlab-ctl renew-le-certs`.
+	if !strings.EqualFold(gitlabValue(lines, `letsencrypt\[['"]enable['"]\]\s*=\s*(true|false)`), "false") {
+		log.Printf("GitLab Let's Encrypt is not explicitly disabled (letsencrypt['enable'] is not false); skipping GitLab certificates from inventory")
+		return nil
+	}
 
 	items := make([]api.InventoryItem, 0)
 	for _, svc := range gitlabServices {
@@ -73,11 +74,8 @@ func parseGitLabConfig(data []byte, path, fqdn string) []api.InventoryItem {
 		cert := gitlabValue(lines, regexp.QuoteMeta(svc.nginxKey)+`\[['"]ssl_certificate['"]\]\s*=\s*['"](.*?)['"]`)
 		key := gitlabValue(lines, regexp.QuoteMeta(svc.nginxKey)+`\[['"]ssl_certificate_key['"]\]\s*=\s*['"](.*?)['"]`)
 
+		// No explicit cert: GitLab serves a self-signed at its default path.
 		if cert == "" {
-			if !leDisabled {
-				continue // GitLab-managed via Let's Encrypt
-			}
-			// No explicit cert: GitLab serves a self-signed at its default path.
 			cert = fmt.Sprintf("/etc/gitlab/ssl/%s.crt", fqdn)
 		}
 		if key == "" {

--- a/inventory/gitlab.test.rb
+++ b/inventory/gitlab.test.rb
@@ -2,7 +2,6 @@
 ##! GitLab inventory provider. It exercises every service the provider reports:
 ##!   - gitlab            (main nginx, cert via #{node['fqdn']} interpolation)
 ##!   - gitlab-registry   (Container Registry, explicit literal cert)
-##!   - gitlab-mattermost (Mattermost, explicit literal cert)
 ##!   - gitlab-pages      (GitLab Pages, explicit literal cert)
 ##!
 ##! letsencrypt['enable'] is false here so the bundled certs are treated as
@@ -15,8 +14,8 @@ external_url 'https://gitlab.example.com'
 # certkit-manageable instead of being skipped as GitLab-managed.
 letsencrypt['enable'] = false
 
-# Main GitLab nginx vhost. The default template uses #{node['fqdn']} in the
-# filename; the provider substitutes it with the external_url host.
+# Main GitLab nginx vhost. GitLab/Chef resolves #{node['fqdn']} to the
+# machine FQDN from hostname -f, not the external_url host.
 nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"
 nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"
 
@@ -24,11 +23,6 @@ nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"
 registry_external_url 'https://registry.example.com:5050'
 registry_nginx['ssl_certificate'] = "/etc/gitlab/ssl/registry.example.com.crt"
 registry_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/registry.example.com.key"
-
-# Bundled Mattermost.
-mattermost_external_url 'https://mattermost.example.com'
-mattermost_nginx['ssl_certificate'] = "/etc/gitlab/ssl/mattermost.example.com.crt"
-mattermost_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/mattermost.example.com.key"
 
 # GitLab Pages.
 pages_external_url 'https://pages.example.com'

--- a/inventory/gitlab.test.rb
+++ b/inventory/gitlab.test.rb
@@ -1,0 +1,43 @@
+##! Sample GitLab Omnibus configuration used as a reference fixture for the
+##! GitLab inventory provider. It exercises every service the provider reports:
+##!   - gitlab            (main nginx, cert via #{node['fqdn']} interpolation)
+##!   - gitlab-registry   (Container Registry, explicit literal cert)
+##!   - gitlab-mattermost (Mattermost, explicit literal cert)
+##!   - gitlab-pages      (GitLab Pages, explicit literal cert)
+##!
+##! letsencrypt['enable'] is false here so the bundled certs are treated as
+##! locally managed rather than auto-renewed by GitLab. The commented-out lines
+##! and unrelated settings below are intentional noise the parser must ignore.
+
+external_url 'https://gitlab.example.com'
+
+# Disable GitLab's built-in Let's Encrypt so the certs below are reported as
+# certkit-manageable instead of being skipped as GitLab-managed.
+letsencrypt['enable'] = false
+
+# Main GitLab nginx vhost. The default template uses #{node['fqdn']} in the
+# filename; the provider substitutes it with the external_url host.
+nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"
+nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"
+
+# Container Registry on its own subdomain/port.
+registry_external_url 'https://registry.example.com:5050'
+registry_nginx['ssl_certificate'] = "/etc/gitlab/ssl/registry.example.com.crt"
+registry_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/registry.example.com.key"
+
+# Bundled Mattermost.
+mattermost_external_url 'https://mattermost.example.com'
+mattermost_nginx['ssl_certificate'] = "/etc/gitlab/ssl/mattermost.example.com.crt"
+mattermost_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/mattermost.example.com.key"
+
+# GitLab Pages.
+pages_external_url 'https://pages.example.com'
+pages_nginx['ssl_certificate'] = "/etc/gitlab/ssl/pages.example.com.crt"
+pages_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/pages.example.com.key"
+
+# --- Unrelated settings the provider should ignore -------------------------
+gitlab_rails['gitlab_shell_ssh_port'] = 22
+gitlab_rails['time_zone'] = 'UTC'
+# nginx['redirect_http_to_https'] = true
+# nginx['listen_port'] = 443
+prometheus_monitoring['enable'] = false

--- a/inventory/gitlab_test.go
+++ b/inventory/gitlab_test.go
@@ -1,15 +1,15 @@
 package inventory
 
 import (
-	"os"
 	"testing"
 
 	"github.com/certkit-io/certkit-agent/api"
 )
 
 const (
-	gitlabConfigPath = "/etc/gitlab/gitlab.rb"
+	gitlabConfigPath = gitlabConfigFile
 	testFQDN         = "host01.internal.example.com"
+	leOff            = "letsencrypt['enable'] = false\n"
 )
 
 func TestParseGitLabConfig(t *testing.T) {
@@ -18,145 +18,95 @@ func TestParseGitLabConfig(t *testing.T) {
 		config string
 		want   []api.InventoryItem
 	}{
+		// --- Let's Encrypt gate: only an explicit `false` allows discovery ------
 		{
-			name:   "stock default lets encrypt auto-enabled is skipped",
-			config: "external_url 'https://gitlab.example.com'\n",
+			name:   "lets encrypt true is skipped even with an explicit cert",
+			config: "external_url 'https://gitlab.example.com'\nletsencrypt['enable'] = true\n" + explicitMainCert,
 			want:   nil,
 		},
 		{
-			name: "lets encrypt disabled falls back to the MACHINE FQDN path",
-			config: "external_url 'https://gitlab.example.com'\n" +
-				"letsencrypt['enable'] = false\n",
+			name:   "lets encrypt unset is skipped even with an explicit cert",
+			config: "external_url 'https://gitlab.example.com'\n" + explicitMainCert,
+			want:   nil,
+		},
+		{
+			name:   "lets encrypt commented out is skipped",
+			config: "external_url 'https://gitlab.example.com'\n# letsencrypt['enable'] = false\n" + explicitMainCert,
+			want:   nil,
+		},
+
+		// --- letsencrypt['enable'] = false: discovery is allowed ---------------
+		{
+			name:   "false with no cert falls back to the MACHINE FQDN self-signed path",
+			config: leOff + "external_url 'https://gitlab.example.com'\n",
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
-					Domains:         "gitlab.example.com",
-				},
+				gitlabItem("gitlab", "/etc/gitlab/ssl/host01.internal.example.com.crt", "/etc/gitlab/ssl/host01.internal.example.com.key", "gitlab.example.com"),
 			},
 		},
 		{
-			name: "explicit cert with node fqdn interpolation uses the machine FQDN",
-			config: "external_url 'https://gitlab.example.com'\n" +
-				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n" +
-				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"` + "\n",
+			name:   "false with node fqdn interpolation uses the machine FQDN",
+			config: leOff + "external_url 'https://gitlab.example.com'\n" + explicitMainCert,
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
-					Domains:         "gitlab.example.com",
-				},
+				gitlabItem("gitlab", "/etc/gitlab/ssl/host01.internal.example.com.crt", "/etc/gitlab/ssl/host01.internal.example.com.key", "gitlab.example.com"),
 			},
 		},
 		{
-			name: "explicit literal paths with single quotes",
-			config: `external_url "https://gitlab.example.com"` + "\n" +
+			name: "false with explicit literal paths and single quotes",
+			config: leOff + `external_url "https://gitlab.example.com"` + "\n" +
 				`nginx['ssl_certificate'] = '/secure/certs/gitlab.crt'` + "\n" +
 				`nginx['ssl_certificate_key'] = '/secure/certs/gitlab.key'` + "\n",
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/secure/certs/gitlab.crt",
-					KeyPath:         "/secure/certs/gitlab.key",
-					Domains:         "gitlab.example.com",
-				},
+				gitlabItem("gitlab", "/secure/certs/gitlab.crt", "/secure/certs/gitlab.key", "gitlab.example.com"),
 			},
 		},
 		{
-			name: "tolerates missing and tab-separated assignment spacing",
-			config: "external_url 'https://gitlab.example.com'\n" +
+			name: "false tolerates missing and tab-separated assignment spacing",
+			config: leOff + "external_url 'https://gitlab.example.com'\n" +
 				"nginx['ssl_certificate']=\"/secure/nospace.crt\"\n" +
 				"nginx['ssl_certificate_key']\t=\t\"/secure/tab.key\"\n",
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/secure/nospace.crt",
-					KeyPath:         "/secure/tab.key",
-					Domains:         "gitlab.example.com",
-				},
+				gitlabItem("gitlab", "/secure/nospace.crt", "/secure/tab.key", "gitlab.example.com"),
 			},
 		},
 		{
-			name: "registry and mattermost become separate items",
-			config: "external_url 'https://gitlab.example.com'\n" +
-				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"` + "\n" +
-				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"` + "\n" +
+			name: "false reports supported GitLab services as separate items",
+			config: leOff + "external_url 'https://gitlab.example.com'\n" + explicitMainCert +
 				"registry_external_url 'https://registry.example.com:5050'\n" +
 				`registry_nginx['ssl_certificate'] = "/etc/gitlab/ssl/registry.example.com.crt"` + "\n" +
 				`registry_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/registry.example.com.key"` + "\n" +
-				"mattermost_external_url 'https://mattermost.example.com'\n" +
-				`mattermost_nginx['ssl_certificate'] = "/etc/gitlab/ssl/mattermost.example.com.crt"` + "\n" +
-				`mattermost_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/mattermost.example.com.key"` + "\n",
+				"pages_external_url 'https://pages.example.com'\n" +
+				`pages_nginx['ssl_certificate'] = "/etc/gitlab/ssl/pages.example.com.crt"` + "\n" +
+				`pages_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/pages.example.com.key"` + "\n",
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/gitlab.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/gitlab.example.com.key",
-					Domains:         "gitlab.example.com",
-				},
-				{
-					Server:          "gitlab-registry",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/registry.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/registry.example.com.key",
-					Domains:         "registry.example.com",
-				},
-				{
-					Server:          "gitlab-mattermost",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/mattermost.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/mattermost.example.com.key",
-					Domains:         "mattermost.example.com",
-				},
+				gitlabItem("gitlab", "/etc/gitlab/ssl/host01.internal.example.com.crt", "/etc/gitlab/ssl/host01.internal.example.com.key", "gitlab.example.com"),
+				gitlabItem("gitlab-registry", "/etc/gitlab/ssl/registry.example.com.crt", "/etc/gitlab/ssl/registry.example.com.key", "registry.example.com"),
+				gitlabItem("gitlab-pages", "/etc/gitlab/ssl/pages.example.com.crt", "/etc/gitlab/ssl/pages.example.com.key", "pages.example.com"),
 			},
 		},
 		{
-			name: "lets-encrypt-managed registry is skipped while explicit main is kept",
-			config: "external_url 'https://gitlab.example.com'\n" +
-				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"` + "\n" +
-				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"` + "\n" +
-				"registry_external_url 'https://registry.example.com'\n",
+			name: "false ignores commented cert lines and falls back to the machine FQDN",
+			config: leOff + "external_url 'https://gitlab.example.com'\n" +
+				`# nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n",
 			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/gitlab.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/gitlab.example.com.key",
-					Domains:         "gitlab.example.com",
-				},
+				gitlabItem("gitlab", "/etc/gitlab/ssl/host01.internal.example.com.crt", "/etc/gitlab/ssl/host01.internal.example.com.key", "gitlab.example.com"),
 			},
 		},
+
+		// --- Edge cases (LE off, but nothing to report) -----------------------
 		{
 			name:   "http-only external_url yields no items",
-			config: "external_url 'http://gitlab.example.com'\n",
+			config: leOff + "external_url 'http://gitlab.example.com'\n",
 			want:   nil,
 		},
 		{
 			name:   "no external_url yields no items",
-			config: "gitlab_rails['gitlab_shell_ssh_port'] = 22\n",
+			config: leOff + "gitlab_rails['gitlab_shell_ssh_port'] = 22\n",
 			want:   nil,
 		},
 		{
-			name: "commented cert lines are ignored and fall back to the machine FQDN",
-			config: "external_url 'https://gitlab.example.com'\n" +
-				`# nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n" +
-				"letsencrypt['enable'] = false\n",
-			want: []api.InventoryItem{
-				{
-					Server:          "gitlab",
-					ConfigPath:      gitlabConfigPath,
-					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
-					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
-					Domains:         "gitlab.example.com",
-				},
-			},
+			name:   "malformed garbage yields no items",
+			config: leOff + "this is not valid ruby\n\x00\x01 nginx[ ssl_certificate = \nexternal_url =\n}}}{{{",
+			want:   nil,
 		},
 	}
 
@@ -168,46 +118,13 @@ func TestParseGitLabConfig(t *testing.T) {
 	}
 }
 
-// TestParseGitLabSampleConfig runs the gitlab.test.rb sample through the parser,
-// exercising all four services end-to-end.
-func TestParseGitLabSampleConfig(t *testing.T) {
-	data, err := os.ReadFile("gitlab.test.rb")
-	if err != nil {
-		t.Fatal(err)
+// TestGitLabCollectNeverErrors guards the "don't blow up the agent" contract:
+// Collect must not return an error even when /etc/gitlab/gitlab.rb is absent
+// (the usual case on a non-GitLab host).
+func TestGitLabCollectNeverErrors(t *testing.T) {
+	if _, err := (GitLabProvider{}).Collect(); err != nil {
+		t.Fatalf("Collect returned error: %v", err)
 	}
-
-	got := parseGitLabConfig(data, gitlabConfigPath, testFQDN)
-	want := []api.InventoryItem{
-		{
-			Server:          "gitlab",
-			ConfigPath:      gitlabConfigPath,
-			CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
-			KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
-			Domains:         "gitlab.example.com",
-		},
-		{
-			Server:          "gitlab-registry",
-			ConfigPath:      gitlabConfigPath,
-			CertificatePath: "/etc/gitlab/ssl/registry.example.com.crt",
-			KeyPath:         "/etc/gitlab/ssl/registry.example.com.key",
-			Domains:         "registry.example.com",
-		},
-		{
-			Server:          "gitlab-mattermost",
-			ConfigPath:      gitlabConfigPath,
-			CertificatePath: "/etc/gitlab/ssl/mattermost.example.com.crt",
-			KeyPath:         "/etc/gitlab/ssl/mattermost.example.com.key",
-			Domains:         "mattermost.example.com",
-		},
-		{
-			Server:          "gitlab-pages",
-			ConfigPath:      gitlabConfigPath,
-			CertificatePath: "/etc/gitlab/ssl/pages.example.com.crt",
-			KeyPath:         "/etc/gitlab/ssl/pages.example.com.key",
-			Domains:         "pages.example.com",
-		},
-	}
-	assertInventoryItems(t, got, want)
 }
 
 func TestNodeFQDN(t *testing.T) {
@@ -215,6 +132,19 @@ func TestNodeFQDN(t *testing.T) {
 	// never /etc/gitlab/ssl/.crt.
 	if nodeFQDN() == "" {
 		t.Error("nodeFQDN() returned empty string")
+	}
+}
+
+const explicitMainCert = `nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n" +
+	`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"` + "\n"
+
+func gitlabItem(server, cert, key, domains string) api.InventoryItem {
+	return api.InventoryItem{
+		Server:          server,
+		ConfigPath:      gitlabConfigPath,
+		CertificatePath: cert,
+		KeyPath:         key,
+		Domains:         domains,
 	}
 }
 

--- a/inventory/gitlab_test.go
+++ b/inventory/gitlab_test.go
@@ -1,0 +1,231 @@
+package inventory
+
+import (
+	"os"
+	"testing"
+
+	"github.com/certkit-io/certkit-agent/api"
+)
+
+const (
+	gitlabConfigPath = "/etc/gitlab/gitlab.rb"
+	testFQDN         = "host01.internal.example.com"
+)
+
+func TestParseGitLabConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   []api.InventoryItem
+	}{
+		{
+			name:   "stock default lets encrypt auto-enabled is skipped",
+			config: "external_url 'https://gitlab.example.com'\n",
+			want:   nil,
+		},
+		{
+			name: "lets encrypt disabled falls back to the MACHINE FQDN path",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				"letsencrypt['enable'] = false\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+		{
+			name: "explicit cert with node fqdn interpolation uses the machine FQDN",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n" +
+				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/#{node['fqdn']}.key"` + "\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+		{
+			name: "explicit literal paths with single quotes",
+			config: `external_url "https://gitlab.example.com"` + "\n" +
+				`nginx['ssl_certificate'] = '/secure/certs/gitlab.crt'` + "\n" +
+				`nginx['ssl_certificate_key'] = '/secure/certs/gitlab.key'` + "\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/secure/certs/gitlab.crt",
+					KeyPath:         "/secure/certs/gitlab.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+		{
+			name: "tolerates missing and tab-separated assignment spacing",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				"nginx['ssl_certificate']=\"/secure/nospace.crt\"\n" +
+				"nginx['ssl_certificate_key']\t=\t\"/secure/tab.key\"\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/secure/nospace.crt",
+					KeyPath:         "/secure/tab.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+		{
+			name: "registry and mattermost become separate items",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"` + "\n" +
+				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"` + "\n" +
+				"registry_external_url 'https://registry.example.com:5050'\n" +
+				`registry_nginx['ssl_certificate'] = "/etc/gitlab/ssl/registry.example.com.crt"` + "\n" +
+				`registry_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/registry.example.com.key"` + "\n" +
+				"mattermost_external_url 'https://mattermost.example.com'\n" +
+				`mattermost_nginx['ssl_certificate'] = "/etc/gitlab/ssl/mattermost.example.com.crt"` + "\n" +
+				`mattermost_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/mattermost.example.com.key"` + "\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/gitlab.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/gitlab.example.com.key",
+					Domains:         "gitlab.example.com",
+				},
+				{
+					Server:          "gitlab-registry",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/registry.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/registry.example.com.key",
+					Domains:         "registry.example.com",
+				},
+				{
+					Server:          "gitlab-mattermost",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/mattermost.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/mattermost.example.com.key",
+					Domains:         "mattermost.example.com",
+				},
+			},
+		},
+		{
+			name: "lets-encrypt-managed registry is skipped while explicit main is kept",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				`nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab.example.com.crt"` + "\n" +
+				`nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab.example.com.key"` + "\n" +
+				"registry_external_url 'https://registry.example.com'\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/gitlab.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/gitlab.example.com.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+		{
+			name:   "http-only external_url yields no items",
+			config: "external_url 'http://gitlab.example.com'\n",
+			want:   nil,
+		},
+		{
+			name:   "no external_url yields no items",
+			config: "gitlab_rails['gitlab_shell_ssh_port'] = 22\n",
+			want:   nil,
+		},
+		{
+			name: "commented cert lines are ignored and fall back to the machine FQDN",
+			config: "external_url 'https://gitlab.example.com'\n" +
+				`# nginx['ssl_certificate'] = "/etc/gitlab/ssl/#{node['fqdn']}.crt"` + "\n" +
+				"letsencrypt['enable'] = false\n",
+			want: []api.InventoryItem{
+				{
+					Server:          "gitlab",
+					ConfigPath:      gitlabConfigPath,
+					CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
+					KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
+					Domains:         "gitlab.example.com",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGitLabConfig([]byte(tt.config), gitlabConfigPath, testFQDN)
+			assertInventoryItems(t, got, tt.want)
+		})
+	}
+}
+
+// TestParseGitLabSampleConfig runs the gitlab.test.rb sample through the parser,
+// exercising all four services end-to-end.
+func TestParseGitLabSampleConfig(t *testing.T) {
+	data, err := os.ReadFile("gitlab.test.rb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseGitLabConfig(data, gitlabConfigPath, testFQDN)
+	want := []api.InventoryItem{
+		{
+			Server:          "gitlab",
+			ConfigPath:      gitlabConfigPath,
+			CertificatePath: "/etc/gitlab/ssl/host01.internal.example.com.crt",
+			KeyPath:         "/etc/gitlab/ssl/host01.internal.example.com.key",
+			Domains:         "gitlab.example.com",
+		},
+		{
+			Server:          "gitlab-registry",
+			ConfigPath:      gitlabConfigPath,
+			CertificatePath: "/etc/gitlab/ssl/registry.example.com.crt",
+			KeyPath:         "/etc/gitlab/ssl/registry.example.com.key",
+			Domains:         "registry.example.com",
+		},
+		{
+			Server:          "gitlab-mattermost",
+			ConfigPath:      gitlabConfigPath,
+			CertificatePath: "/etc/gitlab/ssl/mattermost.example.com.crt",
+			KeyPath:         "/etc/gitlab/ssl/mattermost.example.com.key",
+			Domains:         "mattermost.example.com",
+		},
+		{
+			Server:          "gitlab-pages",
+			ConfigPath:      gitlabConfigPath,
+			CertificatePath: "/etc/gitlab/ssl/pages.example.com.crt",
+			KeyPath:         "/etc/gitlab/ssl/pages.example.com.key",
+			Domains:         "pages.example.com",
+		},
+	}
+	assertInventoryItems(t, got, want)
+}
+
+func TestNodeFQDN(t *testing.T) {
+	// Host-dependent value, but it must be non-empty so the default cert path is
+	// never /etc/gitlab/ssl/.crt.
+	if nodeFQDN() == "" {
+		t.Error("nodeFQDN() returned empty string")
+	}
+}
+
+func assertInventoryItems(t *testing.T, got, want []api.InventoryItem) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d\n got: %+v\nwant: %+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("item %d mismatch:\n got: %+v\nwant: %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/inventory/providers_linux.go
+++ b/inventory/providers_linux.go
@@ -9,5 +9,6 @@ func getProviders() []Provider {
 		LitespeedProvider{},
 		HaproxyProvider{},
 		DockerProvider{},
+		GitLabProvider{},
 	}
 }


### PR DESCRIPTION
Tested on Linux Omnibus GitLab install.  Enforces that LetsEncrypt automatic certificates are disabled before producing inventory for GitLab.