### PR TITLE
Better inventory logs

### DIFF
--- a/api/update-inventory.go
+++ b/api/update-inventory.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"time"
 
@@ -34,8 +33,6 @@ func UpdateInventory(items []InventoryItem) error {
 	payload := InventoryUpdate{
 		Items: items,
 	}
-
-	log.Printf("Auto-discovered software: %v", payload)
 
 	requestBody, err := json.Marshal(payload)
 	if err != nil {

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -22,6 +23,9 @@ func Collect() ([]api.InventoryItem, error) {
 		providerItems, err := provider.Collect()
 		if err != nil {
 			return nil, fmt.Errorf("%s inventory: %w", provider.Name(), err)
+		}
+		if len(providerItems) == 0 {
+			log.Printf("[Auto-Discovery] (%s) - not found on this server. Skipping...", provider.Name())
 		}
 		items = append(items, providerItems...)
 	}

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -26,6 +26,11 @@ func Collect() ([]api.InventoryItem, error) {
 		}
 		if len(providerItems) == 0 {
 			log.Printf("[Auto-Discovery] (%s) - not found on this server. Skipping...", provider.Name())
+		} else {
+			for _, item := range providerItems {
+				log.Printf("[Auto-Discovery] (%s) - Found software: (config=%s, cert=%s, key=%s, domains=%s)",
+					provider.Name(), item.ConfigPath, item.CertificatePath, item.KeyPath, item.Domains)
+			}
 		}
 		items = append(items, providerItems...)
 	}

--- a/inventory/rdp_windows.go
+++ b/inventory/rdp_windows.go
@@ -118,10 +118,15 @@ type rdCertResultSet struct {
 func collectRDCertificates() ([]api.InventoryItem, bool) {
 	script := `
 try {
-    try { Import-Module RemoteDesktopServices -ErrorAction Stop } catch {}
+    try { Import-Module RemoteDesktop -ErrorAction Stop } catch { exit 0 }
 
-    $certs = @(Get-RDCertificate -ErrorAction Stop)
-    if ($certs.Count -eq 0) { return }
+    try {
+        $certs = @(Get-RDCertificate -ErrorAction Stop)
+    } catch {
+        # Get-RDCertificate throws when no RD deployment / certificate is present
+        exit 0
+    }
+    if ($certs.Count -eq 0) { exit 0 }
 
     $results = @()
     foreach ($c in $certs) {
@@ -150,10 +155,11 @@ try {
         }
     }
 
-    if ($results.Count -eq 0) { return }
+    if ($results.Count -eq 0) { exit 0 }
     ,@($results) | ConvertTo-Json -Depth 5
+    exit 0
 } catch {
-    return
+    throw
 }
 `
 	out, err := utils.RunPowerShell(script)

--- a/inventory/rdp_windows.go
+++ b/inventory/rdp_windows.go
@@ -32,6 +32,7 @@ func (RDPProvider) Collect() ([]api.InventoryItem, error) {
 }
 
 type tsResult struct {
+	Enabled    bool   `json:"Enabled"`
 	HasCert    bool   `json:"HasCert"`
 	Thumbprint string `json:"Thumbprint"`
 	Domain     string `json:"Domain"`
@@ -40,6 +41,16 @@ type tsResult struct {
 func collectTerminalServices() ([]api.InventoryItem, bool) {
 	script := `
 try {
+    $tss = Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop |
+        Select-Object -First 1
+
+    if (-not $tss -or $tss.AllowTSConnections -ne 1) {
+        # Remote Desktop is disabled. Windows still auto-generates a self-signed
+        # RDP certificate, so only report Terminal Services inventory when RDP is active.
+        [pscustomobject]@{ Enabled = $false } | ConvertTo-Json
+        return
+    }
+
     $ts = Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TSGeneralSetting -ErrorAction Stop |
         Select-Object -First 1
 
@@ -59,6 +70,7 @@ try {
     } catch {}
 
     [pscustomobject]@{
+        Enabled    = $true
         HasCert    = $true
         Thumbprint = $thumbprint
         Domain     = $domain
@@ -82,6 +94,10 @@ try {
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
 		log.Printf("RDP Terminal Services JSON parse failed: %v", err)
 		return nil, false
+	}
+
+	if !result.Enabled {
+		return nil, true
 	}
 
 	if !result.HasCert {

--- a/inventory/remote_access_windows.go
+++ b/inventory/remote_access_windows.go
@@ -68,9 +68,24 @@ func loadRemoteAccessInventoryFromPowerShell() (remoteAccessInventoryResult, boo
 $domains = @()
 $daInstalled = $false
 $rrasInstalled = $false
+
+if (-not (Get-Command Get-RemoteAccess -ErrorAction SilentlyContinue)) {
+    [pscustomobject]@{
+        DAInstalled   = $false
+        RRASInstalled = $false
+        Domains       = $domains
+    } | ConvertTo-Json -Depth 5
+    return
+}
+
 try {
     $remoteAccess = Get-RemoteAccess -ErrorAction Stop
 } catch {
+    [pscustomobject]@{
+        DAInstalled   = $false
+        RRASInstalled = $false
+        Domains       = $domains
+    } | ConvertTo-Json -Depth 5
     return
 }
 
@@ -105,8 +120,6 @@ if ($remoteAccess -and $remoteAccess.SslCertificate -and $remoteAccess.SslCertif
 		log.Printf("RemoteAccess inventory lookup via PowerShell failed: %v", err)
 		return remoteAccessInventoryResult{}, false
 	}
-
-	log.Print(out)
 
 	raw := strings.TrimSpace(out)
 	if raw == "" || raw == "null" {


### PR DESCRIPTION
The auto discovery providers would occasionally log red herring errors to the file.  And in the negative case they logged nothing.  This normalizes auto discovery logs across all providers:
<img width="837" height="88" alt="image" src="https://github.com/user-attachments/assets/67108f1b-fc2f-46f2-8af8-f4c414819264" />
