### PR TITLE
Handle SNI enabled sites in IIS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ The goal is a codebase that is approachable and reliable. **Simple, procedural, 
 
 - **Windows**
   - Uses `main_windows.go` for service installation and service execution.
-  - IIS synchronization uses Windows certificate store and `IIS:\SslBindings` via PowerShell.
+  - IIS inventory enumerates HTTPS bindings from `IIS:\Sites` (capturing each binding's `sslFlags`). SNI bindings (sslFlags bit `0x1`) are recorded as `site:port:host` destinations, non-SNI as `site:port` — the three-part shape is the agent's only SNI signal on deploy (config_path/domains are not sent back from the app). On deploy a three-part destination makes the binding lookup host-scoped (`-HostHeader`); sslFlags are never modified.
   - PowerShell execution is centralized in `utils/powershell_windows.go`.
 - **Linux**
   - Uses systemd installer in `main_linux.go` and `scripts/install.sh`.

--- a/agent/synchronize_iis_windows.go
+++ b/agent/synchronize_iis_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 func synchronizeIISCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
-	siteName, port, err := parseIISDestination(cfg.PemDestination)
+	siteName, port, host, err := parseIISDestination(cfg.PemDestination)
 	if err != nil {
 		return api.AgentConfigStatusUpdate{
 			ConfigId:       cfg.Id,
@@ -26,41 +26,65 @@ func synchronizeIISCertificate(cfg config.CertificateConfiguration, change Confi
 	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: "IIS",
 		applyFn: func(thumbprint string) (string, error) {
-			return "", applyIISBinding(siteName, port, thumbprint)
+			return "", applyIISBinding(siteName, port, host, thumbprint)
 		},
 	})
 }
 
-func parseIISDestination(value string) (string, string, error) {
+func parseIISDestination(value string) (site string, port string, host string, err error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", "", fmt.Errorf("Error: missing IIS destination (expected site:port)")
+		return "", "", "", fmt.Errorf("Error: missing IIS destination (expected site:port)")
 	}
-	parts := strings.SplitN(value, ":", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Error: invalid IIS destination %q (expected site:port)", value)
+	// site:port, or site:port:host for SNI bindings.
+	parts := strings.SplitN(value, ":", 3)
+	if len(parts) < 2 {
+		return "", "", "", fmt.Errorf("Error: invalid IIS destination %q (expected site:port)", value)
 	}
-	site := strings.TrimSpace(parts[0])
-	port := strings.TrimSpace(parts[1])
+	site = strings.TrimSpace(parts[0])
+	port = strings.TrimSpace(parts[1])
+	if len(parts) == 3 {
+		host = strings.TrimSpace(parts[2])
+	}
 	if site == "" || port == "" {
-		return "", "", fmt.Errorf("Error: invalid IIS destination %q (expected site:port)", value)
+		return "", "", "", fmt.Errorf("Error: invalid IIS destination %q (expected site:port)", value)
 	}
-	return site, port, nil
+	return site, port, host, nil
 }
 
-func applyIISBinding(siteName, port, thumbprint string) error {
+func applyIISBinding(siteName, port, host, thumbprint string) error {
 	if thumbprint == "" {
 		return fmt.Errorf("missing thumbprint for IIS binding")
 	}
-	script := fmt.Sprintf(`
+	script := buildIISBindingScript(siteName, port, host, thumbprint)
+	out, err := utils.RunPowerShell(script)
+	logPowerShellOutput("applyIISBinding", out)
+	return err
+}
+
+func buildIISBindingScript(siteName, port, host, thumbprint string) string {
+	// A non-empty host means the destination is three-part (site:port:host), which
+	// the inventory only produces for SNI bindings.
+	// SNI bindings share an IP:port and differ only by host header, so the
+	// lookup must include the host to land on the right binding.
+	useSNI := host != ""
+	bindingLookup := "Get-WebBinding -Name $site -Protocol https -Port $port"
+	bindingDesc := "site '$site' on port $port"
+	if useSNI {
+		bindingLookup += " -HostHeader $bindingHost"
+		bindingDesc += " for host '$bindingHost'"
+	}
+
+	return fmt.Sprintf(`
 Import-Module WebAdministration
 
-$site     = '%s'
-$port     = '%s'
-$newThumb = '%s'
+$site        = '%s'
+$port        = '%s'
+$bindingHost = '%s'
+$newThumb    = '%s'
 
-$bindings = Get-WebBinding -Name $site -Protocol https -Port $port
-if (-not $bindings) { throw "No HTTPS bindings found for site '$site' on port $port." }
+$bindings = %s
+if (-not $bindings) { throw "No HTTPS bindings found for %s." }
 
 foreach ($binding in @($bindings)) {
     # Resolve currently bound cert thumbprint (if any)
@@ -81,8 +105,5 @@ foreach ($binding in @($bindings)) {
 }
 
 Write-Host "IIS bindings updated."
-`, escapePowerShellString(siteName), escapePowerShellString(port), escapePowerShellString(thumbprint))
-	out, err := utils.RunPowerShell(script)
-	logPowerShellOutput("applyIISBinding", out)
-	return err
+`, escapePowerShellString(siteName), escapePowerShellString(port), escapePowerShellString(host), escapePowerShellString(thumbprint), bindingLookup, bindingDesc)
 }

--- a/agent/synchronize_iis_windows_test.go
+++ b/agent/synchronize_iis_windows_test.go
@@ -1,0 +1,105 @@
+//go:build windows
+
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseIISDestination(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantSite string
+		wantPort string
+		wantHost string
+		wantErr  bool
+	}{
+		{name: "site and port", value: "Default Web Site:443", wantSite: "Default Web Site", wantPort: "443"},
+		{name: "site port and host", value: "Certkit Web Site:44300:test.certkit.io", wantSite: "Certkit Web Site", wantPort: "44300", wantHost: "test.certkit.io"},
+		{name: "trims surrounding whitespace", value: " site : 443 : host ", wantSite: "site", wantPort: "443", wantHost: "host"},
+		{name: "empty", value: "", wantErr: true},
+		{name: "missing port", value: "siteonly", wantErr: true},
+		{name: "blank port", value: "site:", wantErr: true},
+		{name: "blank site", value: ":443", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			site, port, host, err := parseIISDestination(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.value, err)
+			}
+			if site != tt.wantSite || port != tt.wantPort || host != tt.wantHost {
+				t.Fatalf("parseIISDestination(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tt.value, site, port, host, tt.wantSite, tt.wantPort, tt.wantHost)
+			}
+		})
+	}
+}
+
+func TestIISThreePartDestinationDrivesSNI(t *testing.T) {
+	// A three-part destination (site:port:host) is the sole SNI signal: it yields a
+	// host, which makes the binding lookup host-scoped. A two-part destination does
+	// not, and falls back to the historical host-agnostic lookup.
+	site, port, host, err := parseIISDestination("Web:443:app.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host == "" {
+		t.Fatal("expected non-empty host from three-part destination")
+	}
+	if !strings.Contains(buildIISBindingScript(site, port, host, "T"), "-HostHeader $bindingHost") {
+		t.Fatal("three-part destination should produce an SNI (host-scoped) lookup")
+	}
+
+	site, port, host, err = parseIISDestination("Web:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host != "" {
+		t.Fatalf("expected empty host from two-part destination, got %q", host)
+	}
+	if strings.Contains(buildIISBindingScript(site, port, host, "T"), "-HostHeader") {
+		t.Fatal("two-part destination should produce a non-SNI (host-agnostic) lookup")
+	}
+}
+
+func TestBuildIISBindingScriptNonSNI(t *testing.T) {
+	script := buildIISBindingScript("Default Web Site", "443", "", "ABC123")
+
+	if !strings.Contains(script, "Get-WebBinding -Name $site -Protocol https -Port $port\n") {
+		t.Fatalf("non-SNI script missing host-agnostic lookup:\n%s", script)
+	}
+	if strings.Contains(script, "-HostHeader") {
+		t.Fatalf("non-SNI script should not scope by host header:\n%s", script)
+	}
+}
+
+func TestBuildIISBindingScriptSNI(t *testing.T) {
+	script := buildIISBindingScript("Certkit Web Site", "44300", "test.certkit.io", "ABC123")
+
+	if !strings.Contains(script, "Get-WebBinding -Name $site -Protocol https -Port $port -HostHeader $bindingHost") {
+		t.Fatalf("SNI script missing host-scoped lookup:\n%s", script)
+	}
+	if !strings.Contains(script, "$bindingHost = 'test.certkit.io'") {
+		t.Fatalf("SNI script missing host assignment:\n%s", script)
+	}
+}
+
+func TestBuildIISBindingScriptEscapesSingleQuotes(t *testing.T) {
+	script := buildIISBindingScript("Sit'e", "443", "ho'st", "AB'C")
+
+	for _, want := range []string{"$site        = 'Sit''e'", "$bindingHost = 'ho''st'", "$newThumb    = 'AB''C'"} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing escaped assignment %q:\n%s", want, script)
+		}
+	}
+}

--- a/inventory/iis_windows.go
+++ b/inventory/iis_windows.go
@@ -23,32 +23,48 @@ func (IISProvider) Collect() ([]api.InventoryItem, error) {
 	if !ok || len(bindings) == 0 {
 		return nil, nil
 	}
+	return iisInventoryItems(bindings), nil
+}
 
+func iisInventoryItems(bindings []iisBinding) []api.InventoryItem {
 	items := make([]api.InventoryItem, 0, len(bindings))
 	for _, binding := range bindings {
+		host := strings.TrimSpace(binding.Host)
+
 		domains := make([]string, 0, 1)
-		if value, ok := normalizeDomain(binding.Host); ok {
+		if value, ok := normalizeDomain(host); ok {
 			domains = append(domains, value)
 		}
 
-		pemPath := fmt.Sprintf("%s:%d", binding.Site, binding.Port)
+		// For SNI bindings the destination is site:port:host so the deploy side can
+		// target the exact binding. That three-part shape is the agent's only SNI
+		// signal, since config_path and domains are not sent back from the CertKit
+		// app. Non-SNI bindings stay site:port even when they carry a host header.
+		destination := fmt.Sprintf("%s:%s", binding.Site, binding.Port)
+		if binding.SslFlags&iisSslFlagSNI != 0 && host != "" {
+			destination = fmt.Sprintf("%s:%s:%s", binding.Site, binding.Port, host)
+		}
 
 		items = append(items, api.InventoryItem{
 			Server:          "iis",
-			ConfigPath:      "IIS:\\SslBindings",
-			CertificatePath: pemPath,
-			KeyPath:         pemPath,
+			ConfigPath:      fmt.Sprintf("IIS:\\Sites|SslFlags=%d", binding.SslFlags),
+			CertificatePath: destination,
+			KeyPath:         destination,
 			Domains:         joinDomains(domains),
 		})
 	}
 
-	return items, nil
+	return items
 }
 
+// IIS sslFlags bit (0x1) marking a binding as SNI-enabled.
+const iisSslFlagSNI = 1
+
 type iisBinding struct {
-	Site string `json:"Site"`
-	Port int    `json:"Port"`
-	Host string `json:"Host"`
+	Site     string `json:"Site"`
+	Port     string `json:"Port"`
+	Host     string `json:"Host"`
+	SslFlags int    `json:"SslFlags"`
 }
 
 type iisBindingResult struct {
@@ -67,16 +83,20 @@ if (-not (Get-Module -ListAvailable -Name WebAdministration)) {
 Import-Module WebAdministration
 
 ,@(
-    Get-ChildItem IIS:\SslBindings |
+    Get-ChildItem IIS:\Sites |
     ForEach-Object {
-        $port = $_.Port
-        $hostName = $_.Host
+        $site = $_
 
-        foreach ($s in $_.Sites) {
-            [pscustomobject]@{
-                Site = $s.Value
-                Port = $port
-                Host = $hostName
+        foreach ($binding in $site.Bindings.Collection) {
+            if ($binding.protocol -eq 'https') {
+                $parts = $binding.bindingInformation -split ':', 3
+
+                [pscustomobject]@{
+                    Site     = $site.Name
+                    Port     = $parts[1]
+                    Host     = $parts[2]
+                    SslFlags = [int]$binding.sslFlags
+                }
             }
         }
     } |
@@ -89,17 +109,21 @@ Import-Module WebAdministration
 		return nil, false
 	}
 
-	raw := strings.TrimSpace(out)
+	return parseIISBindingsJSON(out), true
+}
 
+// parseIISBindingsJSON decodes the {"value":[...],"Count":N} payload produced by
+// the inventory PowerShell. A decode failure is logged and yields no bindings
+// rather than failing the whole inventory run.
+func parseIISBindingsJSON(raw string) []iisBinding {
+	raw = strings.TrimSpace(raw)
 	if raw == "" || raw == "null" {
-		return nil, true
+		return nil
 	}
 
 	var result iisBindingResult
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
 		log.Printf("IIS SSL bindings JSON parse failed: %v", err)
 	}
-	bindings := result.Value
-
-	return bindings, true
+	return result.Value
 }

--- a/inventory/iis_windows_test.go
+++ b/inventory/iis_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/certkit-io/certkit-agent/api"
+)
+
+// sampleIISBindingsJSON mirrors the real {"value":[...],"Count":N} payload the
+// inventory PowerShell emits (captured from a live applicationHost.config with a
+// multi-SNI site and assorted sslFlags). HTTP bindings are already filtered out
+// by the PowerShell, so they never appear here.
+const sampleIISBindingsJSON = `{
+    "value": [
+        { "Site": "TrackJSWeb", "Port": "443", "Host": "local2.trackjs.com", "SslFlags": 1 },
+        { "Site": "TrackJSWeb", "Port": "443", "Host": "local.trackjs.com", "SslFlags": 0 },
+        { "Site": "Certloop", "Port": "443", "Host": "awesome2.certloop.dev", "SslFlags": 65 },
+        { "Site": "SNI", "Port": "443", "Host": "sni1.trackjs.com", "SslFlags": 1 },
+        { "Site": "SNI", "Port": "443", "Host": "sni2.trackjs.com", "SslFlags": 1 }
+    ],
+    "Count": 5
+}`
+
+func TestParseIISBindingsJSON(t *testing.T) {
+	bindings := parseIISBindingsJSON(sampleIISBindingsJSON)
+	if len(bindings) != 5 {
+		t.Fatalf("expected 5 bindings, got %d", len(bindings))
+	}
+
+	// Spot-check the SNI binding with combined flags (65 = 64|1) survives intact.
+	got := bindings[2]
+	if got.Site != "Certloop" || got.Port != "443" || got.Host != "awesome2.certloop.dev" || got.SslFlags != 65 {
+		t.Fatalf("unexpected binding[2]: %+v", got)
+	}
+
+	// The two SNI bindings share site+port and differ only by host header.
+	if bindings[3].Host == bindings[4].Host {
+		t.Fatalf("expected distinct SNI hosts, got %q twice", bindings[3].Host)
+	}
+}
+
+func TestParseIISBindingsJSONEmpty(t *testing.T) {
+	for _, raw := range []string{"", "null", `{"value":[],"Count":0}`} {
+		if got := parseIISBindingsJSON(raw); len(got) != 0 {
+			t.Fatalf("parseIISBindingsJSON(%q) = %v, want empty", raw, got)
+		}
+	}
+}
+
+func TestIISInventoryItems(t *testing.T) {
+	bindings := []iisBinding{
+		{Site: "SNI", Port: "443", Host: "sni1.trackjs.com", SslFlags: 1},
+		{Site: "TrackJSWeb", Port: "443", Host: "local.trackjs.com", SslFlags: 0},
+		{Site: "Default Web Site", Port: "443", Host: "", SslFlags: 0},
+		{Site: "Certloop", Port: "443", Host: "awesome2.certloop.dev", SslFlags: 65},
+	}
+
+	items := iisInventoryItems(bindings)
+	if len(items) != 4 {
+		t.Fatalf("expected 4 items, got %d", len(items))
+	}
+
+	// Host is appended (site:port:host) only for SNI bindings (sslFlags bit 0x1).
+	// Non-SNI bindings stay site:port even when they carry a host header
+	// (TrackJSWeb). The host is always reported via Domains regardless.
+	want := []api.InventoryItem{
+		{
+			Server:          "iis",
+			ConfigPath:      `IIS:\Sites|SslFlags=1`,
+			CertificatePath: "SNI:443:sni1.trackjs.com",
+			KeyPath:         "SNI:443:sni1.trackjs.com",
+			Domains:         "sni1.trackjs.com",
+		},
+		{
+			Server:          "iis",
+			ConfigPath:      `IIS:\Sites|SslFlags=0`,
+			CertificatePath: "TrackJSWeb:443",
+			KeyPath:         "TrackJSWeb:443",
+			Domains:         "local.trackjs.com",
+		},
+		{
+			Server:          "iis",
+			ConfigPath:      `IIS:\Sites|SslFlags=0`,
+			CertificatePath: "Default Web Site:443",
+			KeyPath:         "Default Web Site:443",
+			Domains:         "",
+		},
+		{
+			Server:          "iis",
+			ConfigPath:      `IIS:\Sites|SslFlags=65`,
+			CertificatePath: "Certloop:443:awesome2.certloop.dev",
+			KeyPath:         "Certloop:443:awesome2.certloop.dev",
+			Domains:         "awesome2.certloop.dev",
+		},
+	}
+
+	for i, w := range want {
+		if items[i] != w {
+			t.Fatalf("item[%d]\n got = %+v\nwant = %+v", i, items[i], w)
+		}
+	}
+}


### PR DESCRIPTION
Previously we only supported a single binding per site.  There are cases where SNI is used and there are multiple bindings per site.  This PR adds support for auto discovering and applying certs in these situations.