### PR TITLE
Centralize http response error handling. Better HTTP error messages.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -51,7 +51,7 @@ func getUpdateVariables(configID string) []utils.UpdateVariable {
 func PollAndSync(forceSync bool) {
 	configChanges, err := PollForConfiguration(forceSync)
 	if err != nil {
-		reportAgentError(err, "", "")
+		reportAgentError(fmt.Errorf("poll: %w", err), "", "")
 		return
 	}
 	if utils.IsAgentUnauthorized() {
@@ -61,7 +61,7 @@ func PollAndSync(forceSync bool) {
 	statuses := SynchronizeCertificates(configChanges, forceSync)
 	if len(statuses) > 0 {
 		if err := api.UpdateConfigStatus(statuses); err != nil {
-			reportAgentError(err, "", "")
+			reportAgentError(fmt.Errorf("update status: %w", err), "", "")
 		}
 	}
 }
@@ -351,8 +351,8 @@ func reportAgentError(err error, configId string, certificateId string) {
 		return
 	}
 
-	if reportErr := api.ReportAgentError(err.Error(), configId, certificateId); reportErr != nil {
-		log.Printf("Error reporting agent error: %v", reportErr)
-	}
+	// Reporting to the server is fire-and-forget; a failure here is itself
+	// usually a network problem already covered by the error we log below.
+	_ = api.ReportAgentError(err.Error(), configId, certificateId)
 	log.Printf("Error: %v", err)
 }

--- a/api/client.go
+++ b/api/client.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// requestTimeout caps the total time for a single API request, including
+	// connection setup, TLS handshake, and reading the response headers.
+	requestTimeout = 10 * time.Second
+
+	// dialTimeout caps how long we wait to establish the TCP connection. When
+	// the host is unreachable because of a network misconfiguration or a
+	// firewall silently dropping packets
+	dialTimeout = 5 * time.Second
+)
+
+// newAPITransport builds an http.Transport tuned to fail fast when the host is
+// unreachable. tlsCfg may be nil to use the default TLS configuration.
+func newAPITransport(tlsCfg *tls.Config) *http.Transport {
+	return &http.Transport{
+		TLSClientConfig:       tlsCfg,
+		DialContext:           (&net.Dialer{Timeout: dialTimeout}).DialContext,
+		TLSHandshakeTimeout:   dialTimeout,
+		ResponseHeaderTimeout: requestTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// newHTTPClient returns the default HTTP client used for API requests.
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   requestTimeout,
+		Transport: newAPITransport(nil),
+	}
+}
+
+// doRequest performs req using client and translates low-level network and
+// timeout failures into a clear, actionable error message.
+func doRequest(client *http.Client, req *http.Request) (*http.Response, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, requestError(req.URL.Host, err)
+	}
+	return resp, nil
+}
+
+// requestError converts the cryptic errors returned by net/http (e.g.
+// "context deadline exceeded (Client.Timeout exceeded while awaiting headers)")
+// into a message that explains the likely cause. host is the target the request
+// was sent to (the CertKit API or a keystore), so the operator can tell which
+// hop is failing.
+func requestError(host string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var netErr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
+		return fmt.Errorf("request to %s timed out. Ensure the agent can access the target host and there are no firewalls impacting communication", host)
+	}
+
+	return fmt.Errorf("could not reach %s. This is likely due to a network configuration error or a downstream host firewall issue: %w", host, err)
+}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// timeoutError is a net.Error whose Timeout() reports true, mimicking the
+// errors net/http returns when a request exceeds its deadline.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return false }
+
+func TestRequestErrorTranslatesTimeouts(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"context deadline", context.DeadlineExceeded},
+		{"net timeout", &net.OpError{Op: "dial", Err: timeoutError{}}},
+		{"wrapped client timeout", fmt.Errorf("Post %q: %w", "https://example", timeoutError{})},
+	}
+
+	const host = "keystore.example.com:8443"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := requestError(host, tc.err)
+			if got == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			msg := got.Error()
+			if !strings.Contains(msg, "timed out") || !strings.Contains(msg, "firewall") {
+				t.Fatalf("timeout error not translated to a friendly message: %q", msg)
+			}
+			if !strings.Contains(msg, host) {
+				t.Fatalf("timeout message should name the target host %q: %q", host, msg)
+			}
+			// The cryptic Go internals must not leak into the user-facing message.
+			if strings.Contains(msg, "Client.Timeout") || strings.Contains(msg, "context deadline") {
+				t.Fatalf("friendly message still leaks low-level detail: %q", msg)
+			}
+		})
+	}
+}
+
+func TestRequestErrorPreservesNonTimeout(t *testing.T) {
+	underlying := errors.New("connection refused")
+	got := requestError("api.example.com:443", fmt.Errorf("dial tcp: %w", underlying))
+	if got == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(got, underlying) {
+		t.Fatalf("non-timeout error should wrap the underlying cause, got: %v", got)
+	}
+	if !strings.Contains(got.Error(), "api.example.com:443") {
+		t.Fatalf("non-timeout message should name the target host: %v", got)
+	}
+}
+
+func TestRequestErrorNil(t *testing.T) {
+	if err := requestError("api.example.com:443", nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestNewHTTPClientTimeoutIsShort guards against a regression where the agent
+// would hang for tens of seconds against an unreachable host.
+func TestNewHTTPClientTimeoutIsShort(t *testing.T) {
+	if c := newHTTPClient(); c.Timeout > 15*time.Second {
+		t.Fatalf("client timeout too long: %v", c.Timeout)
+	}
+}
+
+// TestDoRequestReturnsFriendlyTimeout exercises the real client against a
+// server that never responds, confirming a timeout yields the friendly message.
+func TestDoRequestReturnsFriendlyTimeout(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the client gives up
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	client := &http.Client{Timeout: 100 * time.Millisecond, Transport: newAPITransport(nil)}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	_, err = doRequest(client, req)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected friendly timeout message, got: %v", err)
+	}
+}

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -116,13 +116,9 @@ func PollForConfiguration(forceFullSync bool) (*ConfigurationPollResponse, error
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return nil, fmt.Errorf("http do: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 

--- a/api/fetch-certificate.go
+++ b/api/fetch-certificate.go
@@ -48,7 +48,7 @@ func FetchCertificate(configurationId string, certificateId string) (*FetchCerti
 		client = ksClient
 		baseURL = GetKeystoreHost()
 	} else {
-		client = &http.Client{Timeout: 15 * time.Second}
+		client = newHTTPClient()
 	}
 
 	req, err := http.NewRequest(
@@ -71,9 +71,9 @@ func FetchCertificate(configurationId string, certificateId string) (*FetchCerti
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := doRequest(client, req)
 	if err != nil {
-		return nil, fmt.Errorf("http do: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 

--- a/api/fetch-pfx.go
+++ b/api/fetch-pfx.go
@@ -42,7 +42,7 @@ func FetchPfx(configurationId string, certificateId string) (*FetchPfxResponse, 
 		client = ksClient
 		baseURL = GetKeystoreHost()
 	} else {
-		client = &http.Client{Timeout: 15 * time.Second}
+		client = newHTTPClient()
 	}
 
 	req, err := http.NewRequest(
@@ -65,9 +65,9 @@ func FetchPfx(configurationId string, certificateId string) (*FetchPfxResponse, 
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := doRequest(client, req)
 	if err != nil {
-		return nil, fmt.Errorf("http do: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 

--- a/api/keystore_client.go
+++ b/api/keystore_client.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 )
 
 var (
@@ -38,10 +37,8 @@ func InitKeystoreClient(host string, caCertPEM string) error {
 	}
 
 	client := &http.Client{
-		Timeout: 15 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-		},
+		Timeout:   requestTimeout,
+		Transport: newAPITransport(tlsCfg),
 	}
 
 	keystoreMu.Lock()

--- a/api/register-agent.go
+++ b/api/register-agent.go
@@ -90,21 +90,9 @@ func RegisterAgent() (*RegisterAgentResponse, error) {
 	// Required for JSON
 	req.Header.Set("Content-Type", "application/json")
 
-	// (Optional) Set a timeout at the client level
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	//privKey, _ := auth.DecodePrivateKey(config.CurrentConfig.Auth.KeyPair.PrivateKey)
-
-	// err = auth.SignRequest(req, "Eric", privKey, time.Now())
-	// if err != nil {
-	// 	panic(err)
-	// }
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return nil, fmt.Errorf("http do: %w", err)
+		return nil, err
 	}
 
 	defer resp.Body.Close()

--- a/api/report-error.go
+++ b/api/report-error.go
@@ -57,13 +57,9 @@ func ReportAgentError(message string, configId string, certificateId string) err
 		return fmt.Errorf("sign request: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return fmt.Errorf("http do: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/api/unregister-agent.go
+++ b/api/unregister-agent.go
@@ -44,13 +44,9 @@ func UnregisterAgent(cfg config.Config) error {
 		return fmt.Errorf("sign request: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return fmt.Errorf("http do: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/api/update-inventory.go
+++ b/api/update-inventory.go
@@ -59,13 +59,9 @@ func UpdateInventory(items []InventoryItem) error {
 		return fmt.Errorf("sign request: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return fmt.Errorf("http do: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/api/update-status.go
+++ b/api/update-status.go
@@ -61,13 +61,9 @@ func UpdateConfigStatus(updates []AgentConfigStatusUpdate) error {
 		return fmt.Errorf("sign request: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doRequest(newHTTPClient(), req)
 	if err != nil {
-		return fmt.Errorf("http do: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Our previous HTTP timeout was 15 seconds, we've lowered it to 10 seconds for more responsive failures.  Additionally we now have a 5 second TCP dial timeout which should make unreachable hosts fail that much faster.  Finally, we centralized all HTTP Client calls in one place, with one TLS transport for simplicity.  This allows us to intercept certain errors and provide nicer error messages too (for example in the case of HTTP client timeouts)