### PR TITLE
Exchange support

### DIFF
--- a/agent/synchronize.go
+++ b/agent/synchronize.go
@@ -96,6 +96,9 @@ func synchronizeCertificate(cfg config.CertificateConfiguration, change ConfigCh
 	if strings.EqualFold(cfg.ConfigType, "rdp") {
 		return synchronizeRDPCertificate(cfg, change)
 	}
+	if strings.EqualFold(cfg.ConfigType, "exchange") {
+		return synchronizeExchangeCertificate(cfg, change)
+	}
 	if strings.EqualFold(cfg.ConfigType, "windows-cert-store") {
 		return synchronizeWindowsCertStoreCertificate(cfg, change)
 	}

--- a/agent/synchronize_exchange_other.go
+++ b/agent/synchronize_exchange_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package agent
+
+import (
+	"time"
+
+	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/config"
+)
+
+func synchronizeExchangeCertificate(cfg config.CertificateConfiguration, _ ConfigChange) api.AgentConfigStatusUpdate {
+	status := api.AgentConfigStatusUpdate{
+		ConfigId:       cfg.Id,
+		LastStatusDate: time.Now().UTC(),
+		Status:         statusErrorGeneral,
+		Message:        "Exchange synchronization is only supported on Windows",
+	}
+	return status
+}

--- a/agent/synchronize_exchange_windows.go
+++ b/agent/synchronize_exchange_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/config"
+	"github.com/certkit-io/certkit-agent/inventory"
+	"github.com/certkit-io/certkit-agent/utils"
+)
+
+func synchronizeExchangeCertificate(cfg config.CertificateConfiguration, change ConfigChange) api.AgentConfigStatusUpdate {
+	services := parseExchangeServices(cfg.PemDestination)
+
+	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
+		serviceName: "Exchange",
+		applyFn: func(thumbprint string) (string, error) {
+			return "", applyExchangeCertificate(thumbprint, services)
+		},
+	})
+}
+
+// parseExchangeServices canonicalizes the deploy destination into a safe,
+// comma-separated Exchange services list for Enable-ExchangeCertificate, falling
+// back to the IIS,SMTP template default when the destination carries nothing
+// usable. inventory.CanonicalizeExchangeServices restricts the result to known
+// service tokens, keeping it safe to inject unquoted into -Services.
+func parseExchangeServices(value string) string {
+	if services := inventory.CanonicalizeExchangeServices(value); services != "" {
+		return services
+	}
+	return inventory.DefaultExchangeServices
+}
+
+func applyExchangeCertificate(thumbprint, services string) error {
+	thumbprint = normalizeThumbprint(thumbprint)
+	if thumbprint == "" {
+		return fmt.Errorf("missing thumbprint for Exchange certificate")
+	}
+
+	script := buildExchangeScript(thumbprint, services)
+	out, err := utils.RunPowerShell(script)
+	logPowerShellOutput("applyExchangeCertificate", out)
+	return err
+}
+
+func buildExchangeScript(thumbprint, services string) string {
+	// services is restricted to canonical Exchange service tokens by
+	// parseExchangeServices, so it is safe to inject unquoted.
+	return fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-PSSnapin -Name Microsoft.Exchange.Management.PowerShell.SnapIn -ErrorAction SilentlyContinue)) {
+    Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn -ErrorAction Stop
+}
+
+$thumb = '%s'
+$certPath = "Cert:\LocalMachine\My\" + $thumb
+if (-not (Test-Path $certPath)) {
+    throw "Certificate $thumb not found in LocalMachine\My store."
+}
+
+Enable-ExchangeCertificate -Thumbprint $thumb -Services %s -Force
+
+Write-Host "Exchange certificate $thumb enabled for services %s."
+`, escapePowerShellString(thumbprint), services, services)
+}

--- a/agent/synchronize_exchange_windows_test.go
+++ b/agent/synchronize_exchange_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseExchangeServices(t *testing.T) {
+	// Detailed token canonicalization is covered by utils.CanonicalizeExchangeServices;
+	// here we verify only the deploy-side wrapper: passthrough of a usable list and
+	// the IIS,SMTP fallback when nothing usable remains.
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty falls back to default", value: "", want: "IIS,SMTP"},
+		{name: "all unknown falls back to default", value: "nope,bad", want: "IIS,SMTP"},
+		{name: "passes through usable services", value: "IIS, SMTP, IMAP", want: "IIS,SMTP,IMAP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseExchangeServices(tt.value); got != tt.want {
+				t.Fatalf("parseExchangeServices(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildExchangeScript(t *testing.T) {
+	script := buildExchangeScript("ABC123", "IIS,SMTP")
+
+	for _, want := range []string{
+		"Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn",
+		"$thumb = 'ABC123'",
+		"Enable-ExchangeCertificate -Thumbprint $thumb -Services IIS,SMTP -Force",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildExchangeScriptEscapesThumbprint(t *testing.T) {
+	script := buildExchangeScript("AB'C", "IIS,SMTP")
+	if !strings.Contains(script, "$thumb = 'AB''C'") {
+		t.Fatalf("script missing escaped thumbprint assignment:\n%s", script)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ type CertificateConfiguration struct {
 
 func (c CertificateConfiguration) UsesWindowsCertStore() bool {
 	ct := strings.ToLower(c.ConfigType)
-	return ct == "windows-cert-store" || ct == "iis" || ct == "rdp" || ct == "rras" || ct == "direct-access"
+	return ct == "windows-cert-store" || ct == "iis" || ct == "rdp" || ct == "rras" || ct == "direct-access" || ct == "exchange"
 }
 
 func (c CertificateConfiguration) IsJKS() bool {

--- a/inventory/exchange_windows.go
+++ b/inventory/exchange_windows.go
@@ -25,38 +25,46 @@ func (ExchangeProvider) Collect() ([]api.InventoryItem, error) {
 	return exchangeInventoryItems(certs), nil
 }
 
-// exchangeInventoryItems emits one inventory item per discovered certificate. A
-// given Exchange service (IIS, SMTP, IMAP, ...) can only ever bind one
-// certificate, so service sets are disjoint across certs -- each item's service
-// list is therefore a unique deploy target, and reporting per-cert (rather than a
-// merged union) keeps each certificate's own domains intact.
+// exchangeInventoryItems emits one item per unique Exchange deploy target. The
+// destination is the services list because deployment later passes it to
+// Enable-ExchangeCertificate -Services. When one cert is enabled for several
+// services, those services stay together as one manageable target.
 func exchangeInventoryItems(certs []exchangeCert) []api.InventoryItem {
 	items := make([]api.InventoryItem, 0, len(certs))
+	seenTargets := make(map[string]struct{}, len(certs))
+
 	for _, c := range certs {
-		// The services the certificate actually serves become the deploy
-		// destination, so the renewed certificate is re-enabled for the same set.
 		services := CanonicalizeExchangeServices(c.Services)
 		if services == "" {
-			// Not bound to any service we can deploy to; nothing to manage.
 			continue
 		}
 
-		domains := make([]string, 0)
-		for _, token := range strings.Split(c.Domains, ",") {
-			if normalized, ok := normalizeDomain(token); ok {
-				domains = append(domains, normalized)
-			}
+		domains := exchangeInventoryDomains(c.Domains)
+		targetKey := services + "\x00" + domains
+		if _, ok := seenTargets[targetKey]; ok {
+			continue
 		}
+		seenTargets[targetKey] = struct{}{}
 
 		items = append(items, api.InventoryItem{
 			Server:          "exchange",
 			ConfigPath:      "Exchange",
 			CertificatePath: services,
 			KeyPath:         services,
-			Domains:         joinDomains(domains),
+			Domains:         domains,
 		})
 	}
 	return items
+}
+
+func exchangeInventoryDomains(value string) string {
+	domains := make([]string, 0)
+	for _, token := range strings.Split(value, ",") {
+		if normalized, ok := normalizeDomain(token); ok {
+			domains = append(domains, normalized)
+		}
+	}
+	return joinDomains(domains)
 }
 
 // DefaultExchangeServices matches the CertKit Exchange template default: enable a
@@ -81,9 +89,9 @@ var knownExchangeServices = map[string]string{
 	"smtpclientauth": "SMTPClientAuth",
 }
 
-// CanonicalizeExchangeServices parses a comma-separated services list — either
+// CanonicalizeExchangeServices parses a comma-separated services list -- either
 // the "IIS, SMTP" string Get-ExchangeCertificate emits during inventory or a
-// stored deploy destination — into a canonical, de-duplicated, order-preserving
+// stored deploy destination -- into a canonical, de-duplicated, order-preserving
 // comma-separated list. Unknown tokens and "None" are dropped. Returns "" when
 // nothing usable remains; callers needing a deploy target fall back to
 // DefaultExchangeServices.
@@ -153,8 +161,7 @@ try {
 }
 
 # Report every certificate Exchange has bound to a TLS service (IIS, SMTP, IMAP,
-# POP, UM, Federation, ...). Each service binds only one certificate, so the
-# service sets are disjoint and each certificate is independently manageable.
+# POP, UM, Federation, ...). The service list becomes the deploy target.
 $results = @()
 foreach ($c in $certs) {
     $svc = [string]$c.Services

--- a/inventory/exchange_windows.go
+++ b/inventory/exchange_windows.go
@@ -1,0 +1,206 @@
+//go:build windows
+
+package inventory
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/certkit-io/certkit-agent/api"
+	"github.com/certkit-io/certkit-agent/utils"
+)
+
+type ExchangeProvider struct{}
+
+func (ExchangeProvider) Name() string {
+	return "exchange"
+}
+
+func (ExchangeProvider) Collect() ([]api.InventoryItem, error) {
+	certs, ok := loadExchangeCertificatesFromPowerShell()
+	if !ok {
+		return nil, nil
+	}
+	return exchangeInventoryItems(certs), nil
+}
+
+// exchangeInventoryItems emits one inventory item per discovered certificate. A
+// given Exchange service (IIS, SMTP, IMAP, ...) can only ever bind one
+// certificate, so service sets are disjoint across certs -- each item's service
+// list is therefore a unique deploy target, and reporting per-cert (rather than a
+// merged union) keeps each certificate's own domains intact.
+func exchangeInventoryItems(certs []exchangeCert) []api.InventoryItem {
+	items := make([]api.InventoryItem, 0, len(certs))
+	for _, c := range certs {
+		// The services the certificate actually serves become the deploy
+		// destination, so the renewed certificate is re-enabled for the same set.
+		services := CanonicalizeExchangeServices(c.Services)
+		if services == "" {
+			// Not bound to any service we can deploy to; nothing to manage.
+			continue
+		}
+
+		domains := make([]string, 0)
+		for _, token := range strings.Split(c.Domains, ",") {
+			if normalized, ok := normalizeDomain(token); ok {
+				domains = append(domains, normalized)
+			}
+		}
+
+		items = append(items, api.InventoryItem{
+			Server:          "exchange",
+			ConfigPath:      "Exchange",
+			CertificatePath: services,
+			KeyPath:         services,
+			Domains:         joinDomains(domains),
+		})
+	}
+	return items
+}
+
+// DefaultExchangeServices matches the CertKit Exchange template default: enable a
+// new certificate for IIS and SMTP. Used by the deploy side as the target when a
+// stored destination yields no usable services list. Lives here (rather than in
+// the agent package) because agent imports inventory, not the other way around.
+const DefaultExchangeServices = "IIS,SMTP"
+
+// knownExchangeServices maps lower-cased Exchange service tokens to their
+// canonical Enable-ExchangeCertificate -Services spelling. This is the full set
+// of services Exchange can bind a TLS certificate to. Anything outside it (and
+// "None") is dropped, which keeps the canonicalized result safe to inject
+// unquoted into the PowerShell -Services argument.
+var knownExchangeServices = map[string]string{
+	"federation":     "Federation",
+	"imap":           "IMAP",
+	"pop":            "POP",
+	"um":             "UM",
+	"umcallrouter":   "UMCallRouter",
+	"iis":            "IIS",
+	"smtp":           "SMTP",
+	"smtpclientauth": "SMTPClientAuth",
+}
+
+// CanonicalizeExchangeServices parses a comma-separated services list — either
+// the "IIS, SMTP" string Get-ExchangeCertificate emits during inventory or a
+// stored deploy destination — into a canonical, de-duplicated, order-preserving
+// comma-separated list. Unknown tokens and "None" are dropped. Returns "" when
+// nothing usable remains; callers needing a deploy target fall back to
+// DefaultExchangeServices.
+func CanonicalizeExchangeServices(value string) string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 2)
+	for _, token := range strings.Split(value, ",") {
+		canonical, ok := knownExchangeServices[strings.ToLower(strings.TrimSpace(token))]
+		if !ok {
+			continue
+		}
+		if _, dup := seen[canonical]; dup {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	return strings.Join(out, ",")
+}
+
+// exchangeCert is one discovered Exchange certificate bound to at least one TLS
+// service. Services and Domains are comma-separated strings rather than arrays:
+// ConvertTo-Json unwraps a single-element array into a scalar, which would fail
+// to decode into []string. Splitting a string in Go sidesteps that quirk.
+type exchangeCert struct {
+	Services string `json:"Services"`
+	Domains  string `json:"Domains"`
+}
+
+type exchangeCertResultSet struct {
+	Value []exchangeCert `json:"value"`
+	Count int            `json:"Count"`
+}
+
+func loadExchangeCertificatesFromPowerShell() ([]exchangeCert, bool) {
+	// Fast path first: the registered-snapin check is a cheap registry read, so
+	// non-Exchange servers report "not found" without paying to load the (slow)
+	// Exchange management runtime. Only registered boxes add the snap-in.
+	//
+	// Every discovery path emits a JSON array and exits 0 -- a missing snap-in or
+	// absent Exchange is "not found", never an error.
+	script := `
+$snapin = Get-PSSnapin -Registered -Name Microsoft.Exchange.Management.PowerShell.SnapIn -ErrorAction SilentlyContinue
+if (-not $snapin) {
+    ,@() | ConvertTo-Json
+    exit 0
+}
+
+try {
+    Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn -ErrorAction Stop
+} catch {
+    ,@() | ConvertTo-Json
+    exit 0
+}
+
+if (-not (Get-Command Get-ExchangeCertificate -ErrorAction SilentlyContinue)) {
+    ,@() | ConvertTo-Json
+    exit 0
+}
+
+$certs = @()
+try {
+    $certs = @(Get-ExchangeCertificate -ErrorAction Stop)
+} catch {
+    ,@() | ConvertTo-Json
+    exit 0
+}
+
+# Report every certificate Exchange has bound to a TLS service (IIS, SMTP, IMAP,
+# POP, UM, Federation, ...). Each service binds only one certificate, so the
+# service sets are disjoint and each certificate is independently manageable.
+$results = @()
+foreach ($c in $certs) {
+    $svc = [string]$c.Services
+    if (-not $svc -or $svc -eq 'None') { continue }
+
+    $domains = @()
+    $thumb = ($c.Thumbprint -replace '\s', '')
+    try {
+        $cert = Get-ChildItem ("Cert:\LocalMachine\My\" + $thumb) -ErrorAction Stop
+        if ($cert.DnsNameList -and $cert.DnsNameList.Count -gt 0) {
+            foreach ($d in $cert.DnsNameList) {
+                if (-not [string]::IsNullOrWhiteSpace($d.Unicode)) { $domains += $d.Unicode }
+            }
+        } elseif ($cert.Subject -match 'CN=([^,]+)') {
+            $domains += $Matches[1].Trim()
+        }
+    } catch {}
+
+    $results += [pscustomobject]@{
+        Services = $svc
+        Domains  = ($domains -join ',')
+    }
+}
+
+,@($results) | ConvertTo-Json -Depth 5
+exit 0
+`
+
+	out, err := utils.RunPowerShell(script)
+	if err != nil {
+		log.Printf("Exchange inventory lookup via PowerShell failed: %v", err)
+		return nil, false
+	}
+
+	return parseExchangeCertificatesJSON(out), true
+}
+
+func parseExchangeCertificatesJSON(raw string) []exchangeCert {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil
+	}
+
+	var result exchangeCertResultSet
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		log.Printf("Exchange certificates JSON parse failed: %v", err)
+	}
+	return result.Value
+}

--- a/inventory/exchange_windows_test.go
+++ b/inventory/exchange_windows_test.go
@@ -58,29 +58,52 @@ func TestParseExchangeCertificatesJSONEmpty(t *testing.T) {
 	}
 }
 
-func TestExchangeInventoryItems(t *testing.T) {
-	// One item per discovered certificate. Services drive the destination
-	// (canonicalized, de-duped); wildcard domains normalize to their base and
-	// non-FQDN tokens drop out. A certificate bound to no manageable service is
-	// skipped entirely.
+func TestExchangeInventoryItemsSingleTarget(t *testing.T) {
 	certs := []exchangeCert{
-		{Services: "IIS, SMTP, IMAP, SMTP", Domains: "mail.contoso.com,*.contoso.com,not a domain,mail.contoso.com"},
-		{Services: "IMAP, POP", Domains: "imap.contoso.com"},
+		{Services: "IIS, SMTP, IMAP, POP, SMTP", Domains: "mail.contoso.com,*.contoso.com,not a domain,mail.contoso.com"},
+		{Services: "IIS, SMTP, IMAP, POP, SMTP", Domains: "mail.contoso.com,*.contoso.com,not a domain,mail.contoso.com"},
 		{Services: "None", Domains: "ignored.contoso.com"},
 	}
 
 	items := exchangeInventoryItems(certs)
-	if len(items) != 2 {
-		t.Fatalf("expected 2 items (None-only cert skipped), got %d", len(items))
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (duplicate target and None-only cert skipped), got %d", len(items))
 	}
 
 	want := []api.InventoryItem{
 		{
 			Server:          "exchange",
 			ConfigPath:      "Exchange",
-			CertificatePath: "IIS,SMTP,IMAP",
-			KeyPath:         "IIS,SMTP,IMAP",
+			CertificatePath: "IIS,SMTP,IMAP,POP",
+			KeyPath:         "IIS,SMTP,IMAP,POP",
 			Domains:         "mail.contoso.com,contoso.com",
+		},
+	}
+	for i, w := range want {
+		if items[i] != w {
+			t.Fatalf("item[%d]\n got = %+v\nwant = %+v", i, items[i], w)
+		}
+	}
+}
+
+func TestExchangeInventoryItemsSplitTargets(t *testing.T) {
+	certs := []exchangeCert{
+		{Services: "IIS, SMTP", Domains: "mail.contoso.com"},
+		{Services: "IMAP, POP", Domains: "imap.contoso.com"},
+	}
+
+	items := exchangeInventoryItems(certs)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	want := []api.InventoryItem{
+		{
+			Server:          "exchange",
+			ConfigPath:      "Exchange",
+			CertificatePath: "IIS,SMTP",
+			KeyPath:         "IIS,SMTP",
+			Domains:         "mail.contoso.com",
 		},
 		{
 			Server:          "exchange",

--- a/inventory/exchange_windows_test.go
+++ b/inventory/exchange_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/certkit-io/certkit-agent/api"
+)
+
+func TestCanonicalizeExchangeServices(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "exact", in: "IIS,SMTP", want: "IIS,SMTP"},
+		{name: "powershell spacing", in: "IIS, SMTP", want: "IIS,SMTP"},
+		{name: "case and trim", in: " smtp , iis ", want: "SMTP,IIS"},
+		{name: "drops unknown", in: "IIS,bogus,SMTP", want: "IIS,SMTP"},
+		{name: "drops none", in: "None, SMTP", want: "SMTP"},
+		{name: "all unknown", in: "nope,bad", want: ""},
+		{name: "dedupes", in: "IIS,iis,IIS", want: "IIS"},
+		{name: "extended services", in: "IMAP,POP,UM,UMCallRouter", want: "IMAP,POP,UM,UMCallRouter"},
+		{name: "smtpclientauth", in: "SMTPClientAuth", want: "SMTPClientAuth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalizeExchangeServices(tt.in); got != tt.want {
+				t.Fatalf("CanonicalizeExchangeServices(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseExchangeCertificatesJSON(t *testing.T) {
+	raw := `{ "value": [
+		{ "Services": "IIS, SMTP", "Domains": "mail.contoso.com" },
+		{ "Services": "IMAP, POP", "Domains": "imap.contoso.com" }
+	], "Count": 2 }`
+
+	certs := parseExchangeCertificatesJSON(raw)
+	if len(certs) != 2 {
+		t.Fatalf("expected 2 certs, got %d", len(certs))
+	}
+	if certs[0].Services != "IIS, SMTP" || certs[1].Services != "IMAP, POP" {
+		t.Fatalf("unexpected certs: %+v", certs)
+	}
+}
+
+func TestParseExchangeCertificatesJSONEmpty(t *testing.T) {
+	for _, raw := range []string{"", "null", "   ", `{"value":[],"Count":0}`} {
+		if certs := parseExchangeCertificatesJSON(raw); len(certs) != 0 {
+			t.Fatalf("parseExchangeCertificatesJSON(%q) = %+v, want empty", raw, certs)
+		}
+	}
+}
+
+func TestExchangeInventoryItems(t *testing.T) {
+	// One item per discovered certificate. Services drive the destination
+	// (canonicalized, de-duped); wildcard domains normalize to their base and
+	// non-FQDN tokens drop out. A certificate bound to no manageable service is
+	// skipped entirely.
+	certs := []exchangeCert{
+		{Services: "IIS, SMTP, IMAP, SMTP", Domains: "mail.contoso.com,*.contoso.com,not a domain,mail.contoso.com"},
+		{Services: "IMAP, POP", Domains: "imap.contoso.com"},
+		{Services: "None", Domains: "ignored.contoso.com"},
+	}
+
+	items := exchangeInventoryItems(certs)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items (None-only cert skipped), got %d", len(items))
+	}
+
+	want := []api.InventoryItem{
+		{
+			Server:          "exchange",
+			ConfigPath:      "Exchange",
+			CertificatePath: "IIS,SMTP,IMAP",
+			KeyPath:         "IIS,SMTP,IMAP",
+			Domains:         "mail.contoso.com,contoso.com",
+		},
+		{
+			Server:          "exchange",
+			ConfigPath:      "Exchange",
+			CertificatePath: "IMAP,POP",
+			KeyPath:         "IMAP,POP",
+			Domains:         "imap.contoso.com",
+		},
+	}
+	for i, w := range want {
+		if items[i] != w {
+			t.Fatalf("item[%d]\n got = %+v\nwant = %+v", i, items[i], w)
+		}
+	}
+}
+
+func TestExchangeInventoryItemsEmpty(t *testing.T) {
+	if items := exchangeInventoryItems(nil); len(items) != 0 {
+		t.Fatalf("expected no items, got %+v", items)
+	}
+}

--- a/inventory/iis_windows.go
+++ b/inventory/iis_windows.go
@@ -91,6 +91,12 @@ Import-Module WebAdministration
             if ($binding.protocol -eq 'https') {
                 $parts = $binding.bindingInformation -split ':', 3
 
+                # Skip bindings without a numeric TCP port. Exchange and other
+                # apps register https bindings whose bindingInformation does not
+                # follow the IP:Port:Host shape, leaving a non-numeric value in
+                # $parts[1] (e.g. "Default Web Site:f6b7").
+                if ($parts[1] -notmatch '^\d+$') { continue }
+
                 [pscustomobject]@{
                     Site     = $site.Name
                     Port     = $parts[1]

--- a/inventory/providers_windows.go
+++ b/inventory/providers_windows.go
@@ -7,6 +7,7 @@ func getProviders() []Provider {
 		IISProvider{},
 		RemoteAccessProvider{},
 		RDPProvider{},
+		ExchangeProvider{},
 		ApacheProvider{},
 		FileZillaProvider{},
 	}


### PR DESCRIPTION
This is a first whack at built-in Exchange support.  I was able to test several different configurations on local VMs, but without large scale domain controllers this may not cover all possible configurations.  

Looks like this in the UI:
<img width="1244" height="153" alt="image" src="https://github.com/user-attachments/assets/34c37c6e-a755-4cb5-a1d8-74441da1fd36" />

The certificates are configured by service, not domain, which matches Microsoft's guidance.  How it plays with multiple TLS Receiver Connectors for SMTP is TBD until someone can actually test that scenario.