### PR TITLE
Allow a user to re-run software auto-discovery from the CertKit UI

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -121,6 +121,11 @@ func PollForConfiguration(forceSync bool) (configChanges map[string]ConfigChange
 		)
 	}
 
+	if response.ForceAutodiscover {
+		log.Printf("Auto-discovery requested by server")
+		SendInventory()
+	}
+
 	if response.Keystore != nil {
 		updateKeystoreConfig(response.Keystore)
 	} else if config.CurrentConfig.Keystore != nil {

--- a/api/config-poller.go
+++ b/api/config-poller.go
@@ -33,6 +33,7 @@ type ConfigurationPollResponse struct {
 	LockRequested                    bool                              `json:"lock_requested"`
 	Keystore                         *config.KeystoreConfig            `json:"keystore,omitempty"`
 	UpdateAvailable                  *UpdateSignal                     `json:"update_available,omitempty"`
+	ForceAutodiscover                bool                              `json:"force_autodiscover,omitempty"`
 	VariablesByConfigId              map[string][]utils.UpdateVariable `json:"-"`
 }
 
@@ -49,6 +50,7 @@ type pollResponseWire struct {
 	LockRequested                    bool                   `json:"lock_requested"`
 	Keystore                         *config.KeystoreConfig `json:"keystore,omitempty"`
 	UpdateAvailable                  *UpdateSignal          `json:"update_available,omitempty"`
+	ForceAutodiscover                bool                   `json:"force_autodiscover,omitempty"`
 }
 
 type UpdateSignal struct {
@@ -160,6 +162,7 @@ func PollForConfiguration(forceFullSync bool) (*ConfigurationPollResponse, error
 		LockRequested:                    wire.LockRequested,
 		Keystore:                         wire.Keystore,
 		UpdateAvailable:                  wire.UpdateAvailable,
+		ForceAutodiscover:                wire.ForceAutodiscover,
 		VariablesByConfigId:              varsByID,
 	}, nil
 }

--- a/api/config-poller_test.go
+++ b/api/config-poller_test.go
@@ -55,3 +55,19 @@ func TestPollResponseDecodeKeepsVariablesOffDiskStruct(t *testing.T) {
 	}
 }
 
+func TestPollResponseDecodeForceAutodiscover(t *testing.T) {
+	body := []byte(`{
+		"updated_certificate_configurations": [],
+		"lock_requested": false,
+		"force_autodiscover": true
+	}`)
+
+	var wire pollResponseWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal wire: %v", err)
+	}
+
+	if !wire.ForceAutodiscover {
+		t.Fatal("expected force_autodiscover to decode as true")
+	}
+}


### PR DESCRIPTION
There's now a new button in the agent details section for agents that support this change - 
<img width="558" height="79" alt="image" src="https://github.com/user-attachments/assets/9cab154b-f92e-4905-aa3f-bcdb80292739" />
