### PR TITLE
Proxy installer traffic through app.certkit.io 

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,7 +4,9 @@ Param(
     [string]$InstallDir = "C:\\Program Files\\CertKit",
     [string]$ConfigPath = "C:\\ProgramData\\CertKit\\certkit-agent\\config.json",
     [string]$Owner = "certkit-io",
-    [string]$Repo = "certkit-agent"
+    [string]$Repo = "certkit-agent",
+    # Github is blocked on many customer networks, so downloads go through the CertKit github proxy
+    [string]$GithubProxyBase = "https://app.certkit.io"
 )
 
 $ErrorActionPreference = "Stop"
@@ -26,7 +28,7 @@ function Get-Arch {
 }
 
 function Get-LatestReleaseTag {
-    $uri = "https://api.github.com/repos/$Owner/$Repo/releases/latest"
+    $uri = "$GithubProxyBase/github-api-proxy/repos/$Owner/$Repo/releases/latest"
     $latest = Invoke-RestMethod -Uri $uri -Headers @{ "User-Agent" = "certkit-agent-installer" }
     if (-not $latest) {
         throw "No releases found for $Owner/$Repo"
@@ -151,7 +153,7 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
 
 Write-Host "Using release tag: $Version"
 
-$baseUrl = "https://github.com/$Owner/$Repo/releases/download/$Version"
+$baseUrl = "$GithubProxyBase/github-proxy/$Owner/$Repo/releases/download/$Version"
 $tmp = Join-Path $env:TEMP ("certkit-agent-" + [guid]::NewGuid().ToString())
 New-Item -ItemType Directory -Force -Path $tmp | Out-Null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,9 @@ fi
 OWNER="certkit-io"
 REPO="certkit-agent"
 
+# Github is blocked on many customer networks, so downloads go through the CertKit github proxy
+GITHUB_PROXY_BASE="${GITHUB_PROXY_BASE:-https://app.certkit.io}"
+
 BIN_NAME="certkit-agent"
 INSTALL_DIR="/usr/local/bin"
 
@@ -26,7 +29,7 @@ if [[ -n "${VERSION:-}" ]]; then
   TAG="$VERSION"
 else
   TAG="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
-    "https://github.com/${OWNER}/${REPO}/releases/latest" | sed -n 's#.*/tag/##p')"
+    "${GITHUB_PROXY_BASE}/github-proxy/${OWNER}/${REPO}/releases/latest" | sed -n 's#.*/tag/##p')"
   if [[ -z "$TAG" ]]; then
     echo "Failed to determine latest release tag" >&2
     exit 1
@@ -48,7 +51,7 @@ esac
 
 ASSET_BIN="${BIN_NAME}_linux_${arch}"
 ASSET_SHA="${BIN_NAME}_SHA256SUMS.txt"
-BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download/${TAG}"
+BASE_URL="${GITHUB_PROXY_BASE}/github-proxy/${OWNER}/${REPO}/releases/download/${TAG}"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
Many organizations block outbound traffic to github.com for security reasons.  We host the agent releases on Github so we'll proxy traffic through our domain to prevent issues when installing.