### PR TITLE
Increase IIS bindings discovery limit to 1000 via constant

### DIFF
--- a/inventory/iis_windows.go
+++ b/inventory/iis_windows.go
@@ -60,6 +60,9 @@ func iisInventoryItems(bindings []iisBinding) []api.InventoryItem {
 // IIS sslFlags bit (0x1) marking a binding as SNI-enabled.
 const iisSslFlagSNI = 1
 
+// Maximum number of IIS https bindings to discover in a single collection.
+const iisMaxBindings = 1000
+
 type iisBinding struct {
 	Site     string `json:"Site"`
 	Port     string `json:"Port"`
@@ -73,7 +76,19 @@ type iisBindingResult struct {
 }
 
 func loadIISBindingsFromPowerShell() ([]iisBinding, bool) {
-	script := `
+	out, err := utils.RunPowerShell(iisBindingsScript())
+	if err != nil {
+		log.Printf("IIS SSL bindings lookup via PowerShell failed: %v", err)
+		return nil, false
+	}
+
+	return parseIISBindingsJSON(out), true
+}
+
+// iisBindingsScript builds the PowerShell that enumerates https bindings,
+// capping the result at iisMaxBindings.
+func iisBindingsScript() string {
+	return fmt.Sprintf(`
 
 if (-not (Get-Module -ListAvailable -Name WebAdministration)) {
 	,@() | ConvertTo-Json
@@ -106,16 +121,9 @@ Import-Module WebAdministration
             }
         }
     } |
-    Select-Object -First 250
+    Select-Object -First %d
 ) | ConvertTo-Json
-`
-	out, err := utils.RunPowerShell(script)
-	if err != nil {
-		log.Printf("IIS SSL bindings lookup via PowerShell failed: %v", err)
-		return nil, false
-	}
-
-	return parseIISBindingsJSON(out), true
+`, iisMaxBindings)
 }
 
 // parseIISBindingsJSON decodes the {"value":[...],"Count":N} payload produced by

--- a/inventory/iis_windows_test.go
+++ b/inventory/iis_windows_test.go
@@ -3,10 +3,28 @@
 package inventory
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/certkit-io/certkit-agent/api"
 )
+
+func TestIISBindingsScriptLimit(t *testing.T) {
+	if iisMaxBindings != 1000 {
+		t.Fatalf("iisMaxBindings = %d, want 1000", iisMaxBindings)
+	}
+
+	script := iisBindingsScript()
+	want := fmt.Sprintf("Select-Object -First %d", iisMaxBindings)
+	if !strings.Contains(script, want) {
+		t.Fatalf("script does not embed binding limit %q:\n%s", want, script)
+	}
+	// Guard against the format string leaking an unfilled verb.
+	if strings.Contains(script, "%d") || strings.Contains(script, "%!") {
+		t.Fatalf("script has an unformatted verb:\n%s", script)
+	}
+}
 
 // sampleIISBindingsJSON mirrors the real {"value":[...],"Count":N} payload the
 // inventory PowerShell emits (captured from a live applicationHost.config with a


### PR DESCRIPTION
Move the hardcoded 250 site-binding cap in the discovery PowerShell into a named iisMaxBindings constant and raise it to 1000. Extract the script builder into iisBindingsScript() and add a test covering the limit wiring.