### PR TITLE
Update Exchange Send/Receive connectors to support hybrid/more advanced Exchange setups

### DIFF
--- a/agent/synchronize_exchange_windows.go
+++ b/agent/synchronize_exchange_windows.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/certkit-io/certkit-agent/api"
 	"github.com/certkit-io/certkit-agent/config"
@@ -17,7 +18,7 @@ func synchronizeExchangeCertificate(cfg config.CertificateConfiguration, change 
 	return synchronizeWindowsServiceCert(cfg, change, windowsSyncConfig{
 		serviceName: "Exchange",
 		applyFn: func(thumbprint string) (string, error) {
-			return "", applyExchangeCertificate(thumbprint, services)
+			return applyExchangeCertificate(thumbprint, services)
 		},
 	})
 }
@@ -34,22 +35,39 @@ func parseExchangeServices(value string) string {
 	return inventory.DefaultExchangeServices
 }
 
-func applyExchangeCertificate(thumbprint, services string) error {
+// servicesIncludeSMTP reports whether the canonical comma-separated services
+// list contains the exact SMTP token (SMTPClientAuth does not count). Connector
+// TlsCertificateName updates only apply to SMTP transport deployments.
+func servicesIncludeSMTP(services string) bool {
+	for _, token := range strings.Split(services, ",") {
+		if token == "SMTP" {
+			return true
+		}
+	}
+	return false
+}
+
+func applyExchangeCertificate(thumbprint, services string) (string, error) {
 	thumbprint = normalizeThumbprint(thumbprint)
 	if thumbprint == "" {
-		return fmt.Errorf("missing thumbprint for Exchange certificate")
+		return "", fmt.Errorf("missing thumbprint for Exchange certificate")
 	}
 
 	script := buildExchangeScript(thumbprint, services)
 	out, err := utils.RunPowerShell(script)
 	logPowerShellOutput("applyExchangeCertificate", out)
-	return err
+	if err != nil {
+		// RunPowerShell already wraps the output into err; returning out too
+		// would duplicate it in the status message.
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func buildExchangeScript(thumbprint, services string) string {
 	// services is restricted to canonical Exchange service tokens by
 	// parseExchangeServices, so it is safe to inject unquoted.
-	return fmt.Sprintf(`
+	script := fmt.Sprintf(`
 $ErrorActionPreference = 'Stop'
 
 if (-not (Get-PSSnapin -Name Microsoft.Exchange.Management.PowerShell.SnapIn -ErrorAction SilentlyContinue)) {
@@ -62,8 +80,76 @@ if (-not (Test-Path $certPath)) {
     throw "Certificate $thumb not found in LocalMachine\My store."
 }
 
-Enable-ExchangeCertificate -Thumbprint $thumb -Services %s -Force
-
-Write-Host "Exchange certificate $thumb enabled for services %s."
-`, escapePowerShellString(thumbprint), services, services)
+$wantedServices = @('%s'.Split(','))
+$currentServices = @(([string](Get-ExchangeCertificate -Thumbprint $thumb).Services).Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+$missingServices = @($wantedServices | Where-Object { $currentServices -notcontains $_ })
+if ($missingServices.Count -eq 0) {
+    Write-Host "Exchange certificate $thumb already enabled for services $($wantedServices -join ',')."
+} else {
+    Enable-ExchangeCertificate -Thumbprint $thumb -Services %s -Force
+    Write-Host "Exchange certificate $thumb enabled for services $($wantedServices -join ',')."
 }
+`, escapePowerShellString(thumbprint), services, services)
+
+	if servicesIncludeSMTP(services) {
+		script += exchangeConnectorScript
+	}
+	return script
+}
+
+// exchangeConnectorScript refreshes TlsCertificateName on Send/Receive
+// connectors after the certificate is enabled for SMTP.
+const exchangeConnectorScript = `
+$cert = Get-ExchangeCertificate -Thumbprint $thumb
+$newTls = "<I>$($cert.Issuer)<S>$($cert.Subject)"
+# Comparison-only normalization; the value written is always the exact $newTls.
+$newSubjectCmp = ($cert.Subject -replace ',\s+', ',').Trim()
+$newTlsCmp = ($newTls -replace ',\s+', ',').Trim()
+
+$updated = @()
+$alreadyCurrent = 0
+$otherCert = 0
+$unparsed = @()
+$failed = @()
+
+$targets = @()
+foreach ($rc in @(Get-ReceiveConnector -Server $env:COMPUTERNAME)) { $targets += ,@('Receive', $rc) }
+foreach ($sc in @(Get-SendConnector)) { $targets += ,@('Send', $sc) }
+
+foreach ($t in $targets) {
+    $kind = $t[0]
+    $conn = $t[1]
+    # TlsCertificateName is an SmtpX509Identifier when read from Exchange; [string] yields "<I>...<S>...".
+    $existing = ([string]$conn.TlsCertificateName).Trim()
+    if (-not $existing) { continue }
+
+    if ($existing -notmatch '(?i)^<I>(.*)<S>(.*)$') {
+        $unparsed += "$kind '$($conn.Name)'"
+        continue
+    }
+    $subjectCmp = ($Matches[2] -replace ',\s+', ',').Trim()
+
+    if ($subjectCmp -ne $newSubjectCmp) { $otherCert++; continue }
+    if (($existing -replace ',\s+', ',').Trim() -eq $newTlsCmp) { $alreadyCurrent++; continue }
+
+    try {
+        if ($kind -eq 'Receive') {
+            Set-ReceiveConnector -Identity $conn.Identity -TlsCertificateName $newTls
+        } else {
+            Set-SendConnector -Identity $conn.Identity -TlsCertificateName $newTls
+        }
+        Write-Host "Updated $kind connector '$($conn.Name)' to $newTls"
+        $updated += "$kind '$($conn.Name)'"
+    } catch {
+        $failed += "$kind '$($conn.Name)': $($_.Exception.Message)"
+    }
+}
+
+if ($unparsed.Count -gt 0) {
+    Write-Host "Left alone (unrecognized TlsCertificateName format): $($unparsed -join ', ')"
+}
+if ($failed.Count -gt 0) {
+    throw "The certificate was enabled, but updating TlsCertificateName failed on: $($failed -join '; ')"
+}
+Write-Host "DONE  |  connectors: $($updated.Count) updated, $alreadyCurrent already current, $otherCert bound to a different certificate"
+`

--- a/agent/synchronize_exchange_windows_test.go
+++ b/agent/synchronize_exchange_windows_test.go
@@ -30,6 +30,27 @@ func TestParseExchangeServices(t *testing.T) {
 	}
 }
 
+func TestServicesIncludeSMTP(t *testing.T) {
+	tests := []struct {
+		services string
+		want     bool
+	}{
+		{services: "IIS,SMTP", want: true},
+		{services: "SMTP", want: true},
+		{services: "SMTPClientAuth", want: false},
+		{services: "IIS", want: false},
+		{services: "IIS,SMTPClientAuth,SMTP", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.services, func(t *testing.T) {
+			if got := servicesIncludeSMTP(tt.services); got != tt.want {
+				t.Fatalf("servicesIncludeSMTP(%q) = %t, want %t", tt.services, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildExchangeScript(t *testing.T) {
 	script := buildExchangeScript("ABC123", "IIS,SMTP")
 
@@ -41,6 +62,49 @@ func TestBuildExchangeScript(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
 		}
+	}
+}
+
+func TestBuildExchangeScriptIncludesConnectorBlock(t *testing.T) {
+	script := buildExchangeScript("ABC123", "IIS,SMTP")
+
+	// The regex literal doubles as proof the connector block bypassed
+	// fmt.Sprintf unmangled.
+	for _, want := range []string{
+		"Get-ReceiveConnector -Server $env:COMPUTERNAME",
+		"Get-SendConnector",
+		"Set-ReceiveConnector -Identity $conn.Identity -TlsCertificateName $newTls",
+		"Set-SendConnector -Identity $conn.Identity -TlsCertificateName $newTls",
+		`'(?i)^<I>(.*)<S>(.*)$'`,
+		`"<I>$($cert.Issuer)<S>$($cert.Subject)"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildExchangeScriptOmitsConnectorBlockForNonSMTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		services string
+	}{
+		{name: "iis only", services: "IIS"},
+		{name: "smtp client auth is not smtp", services: "IIS,SMTPClientAuth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := buildExchangeScript("ABC123", tt.services)
+			for _, unwanted := range []string{"Set-SendConnector", "Set-ReceiveConnector", "TlsCertificateName"} {
+				if strings.Contains(script, unwanted) {
+					t.Fatalf("script for services %q should not contain %q:\n%s", tt.services, unwanted, script)
+				}
+			}
+			if !strings.Contains(script, "Enable-ExchangeCertificate -Thumbprint $thumb -Services "+tt.services+" -Force") {
+				t.Fatalf("script missing enable line for services %q:\n%s", tt.services, script)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
In cases where send and receive connectors are setup, ensure we update them as well in case of issuer changes.